### PR TITLE
Remove ES6 syntax in render-datatable.js

### DIFF
--- a/js/render-datatables.js
+++ b/js/render-datatables.js
@@ -57,7 +57,7 @@
         var select = {
             info: false
         };
-        $.extend( settings, { select } ); // jshint ignore:line
+        $.extend( settings, { select: select } ); // jshint ignore:line
 
         var stripe = ['', ''];
 


### PR DESCRIPTION
Wasn't able to see table in IE until fixing this, entirely possible that there's more instances that need to be fixed.