### PR TITLE
Fix: warning with illegal string offset on line 241

### DIFF
--- a/classes/Visualizer/Module/Frontend.php
+++ b/classes/Visualizer/Module/Frontend.php
@@ -236,7 +236,7 @@ class Visualizer_Module_Frontend extends Visualizer_Module {
 		$chart = apply_filters( 'visualizer_schedule_refresh_chart', $chart, $chart->ID, false );
 
 		// fetch and update settings
-		$settings = get_post_meta( $chart->ID, Visualizer_Plugin::CF_SETTINGS, true );
+        $settings = array( get_post_meta( $chart->ID, Visualizer_Plugin::CF_SETTINGS, true ) );
 		if ( empty( $settings['height'] ) ) {
 			$settings['height'] = '400';
 		}


### PR DESCRIPTION
A user had this issue with a warning on the Frontend.

The warning says "illegal string offset on line 241 Frontend.php".

Converting it to an array seems to work. and the user's warning is gone while the charts is rendered correctly.

ticket link -> https://secure.helpscout.net/conversation/961337815/202243?folderId=212385