### PR TITLE
update on cypress e2e GH workflow

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -41,13 +41,11 @@ jobs:
           bash ./bin/run-e2e-tests-${{matrix.env}}.sh
       - name: Run ${{ matrix.env }} Cypress tests
         env:
-          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
         uses: cypress-io/github-action@v2
         with:
           env: host=localhost,port=8080
           browser: chrome
-          record: true
           install: ${{ ! steps.npm-and-build-cache.outputs.cache-hit }}
           headless: true
           spec: cypress/integration/${{ matrix.env }}/**/*


### PR DESCRIPTION
Cypress e2e test was failing on Dependabot E2E test due to CYPRESS_RECORD_KEY. I've removed it and disabled the record since we don't use it anymore.

closes https://github.com/Codeinwp/themeisle/issues/1445