### PR TITLE
Fix multiple charts facade and small google fix

### DIFF
--- a/js/render-facade.js
+++ b/js/render-facade.js
@@ -109,8 +109,8 @@ var vizClipboard1=null;
 
     function initChartDisplay() {
         if(visualizer.is_front == true){ // jshint ignore:line
-                        displayChartsOnFrontEnd();
-        }else{
+            displayChartsOnFrontEnd();
+        } else {
             showChart();
         }
     }

--- a/js/render-facade.js
+++ b/js/render-facade.js
@@ -107,16 +107,6 @@ var vizClipboard1=null;
         registerDefaultActions();
     });
 
-    // Refresh charts if chart not generated.
-    function refreshEachCharts() {
-        if ( 'object' === typeof window.fusionAnimationsVars ) {
-            return;
-        }
-        setTimeout( function() {
-                        displayChartsOnFrontEnd();
-        }, 100 );
-    }
-
     function initChartDisplay() {
         if(visualizer.is_front == true){ // jshint ignore:line
                         displayChartsOnFrontEnd();
@@ -139,22 +129,12 @@ var vizClipboard1=null;
 
     function displayChartsOnFrontEnd() {
 
-        // Render the charts that are not lazy-loaded and with no errors.
-        var nonLazyLoadedCharts = $('div.visualizer-front:not(.viz-facade-loaded):not(.visualizer-lazy):not(.visualizer-cw-error');
-     
-        if ( nonLazyLoadedCharts.length ) {
-            nonLazyLoadedCharts.each(function(index, element){
-                if ( $(element).is(':visible') ) {
-                    var id = $(element).addClass('viz-facade-loaded').attr('id');
-                    showChart(id);
-                }
-            });
-            
-            refreshEachCharts();
-        } else {
-            // Remove the loaded status for charts that are empty.
-            $( 'div.viz-facade-loaded:not(.visualizer-lazy):not(.visualizer-cw-error):empty' ).removeClass( 'viz-facade-loaded' );
-        }
+        $('div.visualizer-front:not(.viz-facade-loaded):not(.visualizer-lazy):not(.visualizer-cw-error):empty').each(function(index, element){
+            if ( $(element).is(':visible') ) {
+                var id = $(element).addClass('viz-facade-loaded').attr('id');
+                showChart(id);
+            }
+        });
 
         // interate through all charts that are to be lazy-loaded and observe each one.
         $('div.visualizer-front.visualizer-lazy').each(function(index, element){

--- a/js/render-facade.js
+++ b/js/render-facade.js
@@ -4,6 +4,9 @@
 var vizClipboard1=null;
 (function($, visualizer){
 
+    // Once the facade is loaded, we need to refresh the charts. But we need to it one time only per chart.
+    var chartReloadedAfterFacade = [];
+
     function initActionsButtons(v) {
         if($('a.visualizer-chart-shortcode').length > 0 && vizClipboard1 === null) {
             vizClipboard1 = new ClipboardJS('a.visualizer-chart-shortcode'); // jshint ignore:line
@@ -144,8 +147,13 @@ var vizClipboard1=null;
             if ( $(element).is(':visible') ) {
                 var id = $(element).addClass('viz-facade-loaded').attr('id');
                 showChart(id);
+
+                // Reload the chart and mark it as reloaded.
+                if ( chartReloadedAfterFacade.indexOf( id ) === -1 ) {
+                    refreshEachCharts();
+                    chartReloadedAfterFacade.push( id );
+                }
             }
-            refreshEachCharts();
         });
 
         // interate through all charts that are to be lazy-loaded and observe each one.

--- a/js/render-facade.js
+++ b/js/render-facade.js
@@ -3,10 +3,7 @@
 /* global jQuery */
 var vizClipboard1=null;
 (function($, visualizer){
-
-    // Once the facade is loaded, we need to refresh the charts. But we need to it one time only per chart.
-    var chartReloadedAfterFacade = [];
-
+    
     function initActionsButtons(v) {
         if($('a.visualizer-chart-shortcode').length > 0 && vizClipboard1 === null) {
             vizClipboard1 = new ClipboardJS('a.visualizer-chart-shortcode'); // jshint ignore:line
@@ -116,13 +113,13 @@ var vizClipboard1=null;
             return;
         }
         setTimeout( function() {
-            displayChartsOnFrontEnd();
+                        displayChartsOnFrontEnd();
         }, 100 );
     }
 
     function initChartDisplay() {
         if(visualizer.is_front == true){ // jshint ignore:line
-            displayChartsOnFrontEnd();
+                        displayChartsOnFrontEnd();
         }else{
             showChart();
         }
@@ -141,20 +138,23 @@ var vizClipboard1=null;
     }
 
     function displayChartsOnFrontEnd() {
-        // display all charts that are NOT to be lazy-loaded.
-        $( 'div.viz-facade-loaded:not(.visualizer-lazy):not(.visualizer-cw-error):empty' ).removeClass( 'viz-facade-loaded' );
-        $('div.visualizer-front:not(.visualizer-lazy):not(.viz-facade-loaded)').each(function(index, element){
-            if ( $(element).is(':visible') ) {
-                var id = $(element).addClass('viz-facade-loaded').attr('id');
-                showChart(id);
 
-                // Reload the chart and mark it as reloaded.
-                if ( chartReloadedAfterFacade.indexOf( id ) === -1 ) {
-                    refreshEachCharts();
-                    chartReloadedAfterFacade.push( id );
+        // Render the charts that are not lazy-loaded and with no errors.
+        var nonLazyLoadedCharts = $('div.visualizer-front:not(.viz-facade-loaded):not(.visualizer-lazy):not(.visualizer-cw-error');
+     
+        if ( nonLazyLoadedCharts.length ) {
+            nonLazyLoadedCharts.each(function(index, element){
+                if ( $(element).is(':visible') ) {
+                    var id = $(element).addClass('viz-facade-loaded').attr('id');
+                    showChart(id);
                 }
-            }
-        });
+            });
+            
+            refreshEachCharts();
+        } else {
+            // Remove the loaded status for charts that are empty.
+            $( 'div.viz-facade-loaded:not(.visualizer-lazy):not(.visualizer-cw-error):empty' ).removeClass( 'viz-facade-loaded' );
+        }
 
         // interate through all charts that are to be lazy-loaded and observe each one.
         $('div.visualizer-front.visualizer-lazy').each(function(index, element){

--- a/js/render-facade.js
+++ b/js/render-facade.js
@@ -132,7 +132,10 @@ var vizClipboard1=null;
         $('div.visualizer-front:not(.viz-facade-loaded):not(.visualizer-lazy):not(.visualizer-cw-error):empty').each(function(index, element){
             if ( $(element).is(':visible') ) {
                 var id = $(element).addClass('viz-facade-loaded').attr('id');
-                showChart(id);
+                setTimeout(function(){
+                    // Add a short delay between each chart to avoid overloading the browser event loop.
+                    showChart(id);
+                }, ( index + 1 ) * 100);
             }
         });
 

--- a/js/render-google.js
+++ b/js/render-google.js
@@ -14,8 +14,17 @@ var isResizeRequest = false;
     var rendered_charts = [];
 
 	function renderChart(id) {
+        
+    if ( ! all_charts || 0 === Object.keys( all_charts ).length ) {
+            return;
+        }
+
         var chart = all_charts[id];
         var hasAnnotation = false;
+
+        if ( ! chart ) {
+            return;
+        }
 
         // re-render the chart only if it doesn't have annotations and it is on the front-end
         // this is to prevent the chart from showing "All series on a given axis must be of the same data type" during resize.

--- a/js/render-google.js
+++ b/js/render-google.js
@@ -15,7 +15,7 @@ var isResizeRequest = false;
 
 	function renderChart(id) {
         
-    if ( ! all_charts || 0 === Object.keys( all_charts ).length ) {
+        if ( ! all_charts || 0 === Object.keys( all_charts ).length ) {
             return;
         }
 


### PR DESCRIPTION
## Summary


The problem: after the first chart started the rendering process, the function `displayChartsOnFrontEnd()`  triggered again.

Because the charts were empty (they were in the process of rendering), this code removed the rendering status `$( 'div.viz-facade-loaded:not(.visualizer-lazy):not(.visualizer-cw-error):empty' ).removeClass( 'viz-facade-loaded' );`

And then this `$('div.visualizer-front:not(.visualizer-lazy):not(.viz-facade-loaded)') put it again in the loop since it considered that they never started the rendering process.

Practically, we were re-rendering the charts that were not finished. 

Thus, the infinite loop was crashing the page.

I simplified the logic. Now, after the page loads, the rendering of the chart is triggered once. 

## Testing

- Check the rendering of the chars; they should not affected.
- Now, Elementor and Gutenberg should not freeze when multiple charts are present.

