### PR TITLE
fix: ignore phpspreadsheet samples folder

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -17,8 +17,8 @@ artifact
 composer.json
 composer.lock
 package-lock.json
-vendor/phpoffice/phpexcel/Examples
-vendor/phpoffice/phpexcel/unitTests
+vendor/phpoffice/phpspreadsheet/samples
+vendor/phpoffice/phpspreadsheet/docs
 cypress
 cypress.json
 .github


### PR DESCRIPTION
Fixes https://github.com/Codeinwp/visualizer-pro/issues/409. 

This issue was accounted before by ignoring the examples files on `.distignore` . 

However the location of those files changed with the update of the package [here](https://github.com/Codeinwp/visualizer/pull/369/files#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L26) .

Updating the path with the current path from the package fixes the issue. 

The tests are no longer present in the package itself, that is why I removed the tests from `.distignore`. 

I also noticed some redundant files were present in the `docs` folder and I also added those to be ignored upon building. 

### For testing

1. Install the pr plugin into a site. 
2. Check that this path https://<your_domain>/wp-content/plugins/visualizer/vendor/phpoffice/phpspreadsheet/samples/Basic/45_Quadratic_equation_solver.php is no longer accessing the file. It will now only show your main page. Before the fix it will display something like: https://vertis.d.pr/i/xS4t9t. 


