### PR TITLE
[Fix] Render the charts that are in hidden containers

### DIFF
--- a/js/render-facade.js
+++ b/js/render-facade.js
@@ -130,13 +130,18 @@ var vizClipboard1=null;
     function displayChartsOnFrontEnd() {
 
         $('div.visualizer-front:not(.viz-facade-loaded):not(.visualizer-lazy):not(.visualizer-cw-error):empty').each(function(index, element){
-            if ( $(element).is(':visible') ) {
-                var id = $(element).addClass('viz-facade-loaded').attr('id');
-                setTimeout(function(){
-                    // Add a short delay between each chart to avoid overloading the browser event loop.
-                    showChart(id);
-                }, ( index + 1 ) * 100);
+
+            // Do not render charts that are intentionally hidden.
+            var style = window.getComputedStyle(element);
+            if (style.display === 'none' || style.visibility === 'hidden') {
+                return;
             }
+           
+            var id = $(element).addClass('viz-facade-loaded').attr('id');
+            setTimeout(function(){
+                // Add a short delay between each chart to avoid overloading the browser event loop.
+                showChart(id);
+            }, ( index + 1 ) * 100);
         });
 
         // interate through all charts that are to be lazy-loaded and observe each one.


### PR DESCRIPTION
## Summary

Replaced the `is(':visible')` check because it did not take in consideration charts placed in containers that are hidden (like Otter Tabs Block)

## Screenshot

https://github.com/Codeinwp/visualizer/assets/17597852/252d7877-b56f-4fd7-ab55-a892cde79529

## Testing (from linked issue)

1. Install Tabby Responsive Tabs
2. Copy this code and paste it on a page:
<pre>
[tabby title="First Tab"]

This is the content of the first tab.

[tabby title="Second Tab"]

This is the content of the second tab.
[tabby title="Third Tab"]

This is the content of the third tab.

[tabbyending]
</pre>
3. Insert one of the Visualizer's shortcodes inside one of the tabs.
4. Publish and check the page

Do the same for Otter:
1. Add the Tabs block
2. Inside one of the tabs, insert a chart's shortcode

Close #1072