### PR TITLE
Changes speed and position for the loading bar

### DIFF
--- a/js/setup-wizard.js
+++ b/js/setup-wizard.js
@@ -11,13 +11,13 @@ jQuery(function ($) {
 		// Import chart data.
 		if ( 1 == id ) {
 			var chartType = $(".vz-radio-btn:checked").val();
-			var percentBarWidth = 100;
+			var percentBarWidth = 0;
 			var loaderDelay;
 			$.ajax( {
 				beforeSend: function() {
 					loaderDelay = setInterval(function () {
 						$('.vz-progress-bar').css({
-							width: percentBarWidth-- + '%'
+							width: percentBarWidth++ + '%'
 						});
 					}, 1000);
 				},
@@ -34,9 +34,9 @@ jQuery(function ($) {
 					clearInterval( loaderDelay );
 					loaderDelay = setInterval(function () {
 						$('.vz-progress-bar').css({
-							width: percentBarWidth-- + '%'
+							width: percentBarWidth++ + '%'
 						});
-						if ( percentBarWidth <= 0 ) {
+						if ( percentBarWidth >= 100 ) {
 							if ( 1 === data.success ) {
 								var importMessage = jQuery('[data-import_message]');
 								importMessage
@@ -53,11 +53,14 @@ jQuery(function ($) {
 								$('#smartwizard').smartWizard('reset');
 							}
 							$('.vz-progress-bar').css({
-								width: 0
+								width: 100 + '%'
+							});
+							$('.vz-progress').css({
+								display: 'none'
 							});
 							clearInterval( loaderDelay );
 						}
-					}, 40 );
+					}, 36 );
 				},
 				error: function() {
 					$('#step-2').find('.vz-progress-bar').animate({ width: '0' });

--- a/js/setup-wizard.js
+++ b/js/setup-wizard.js
@@ -56,7 +56,7 @@ jQuery(function ($) {
 								width: 100 + '%'
 							});
 							$('.vz-progress').css({
-								display: 'none'
+								visibility: 'hidden'
 							});
 							clearInterval( loaderDelay );
 						}

--- a/js/setup-wizard.js
+++ b/js/setup-wizard.js
@@ -57,7 +57,7 @@ jQuery(function ($) {
 							});
 							clearInterval( loaderDelay );
 						}
-					}, 100 );
+					}, 40 );
 				},
 				error: function() {
 					$('#step-2').find('.vz-progress-bar').animate({ width: '0' });

--- a/templates/setup-wizard.php
+++ b/templates/setup-wizard.php
@@ -188,7 +188,7 @@ $last_step_number   = 5;
 														<h4 class="h4 pb-4"><?php esc_html_e( 'Importing demo data', 'visualizer' ); ?></h4>
 														<p class="p" data-import_message="<?php esc_attr_e( 'Done! Demo data imported successfully.', 'visualizer' ); ?>"><?php esc_html_e( 'Hold on! we are importing demo data for your selected chart', 'visualizer' ); ?></p>
 													<div class="vz-progress" style="margin-top: 4px;">
-														<div class="vz-progress-bar" style="width: 100%;"></div>
+														<div class="vz-progress-bar"></div>
 													</div>
 													</div>
 												</div>

--- a/templates/setup-wizard.php
+++ b/templates/setup-wizard.php
@@ -173,13 +173,10 @@ $last_step_number   = 5;
 									<h2 class="h2 pb-8"><?php esc_html_e( 'You\'re almost done!', 'visualizer' ); ?></h2>
 									<p class="p"><?php esc_html_e( 'We use demo data during the import process, don&#x92;t worry you can customize it later', 'visualizer' ); ?></p>
 								</div>
-								<div class="vz-progress">
-									<div class="vz-progress-bar" style="width: 100%;"></div>
-								</div>
 							</div>
 							<div class="vz-accordion-item__content">
 								<div class="vz-form-wrap">
-									<div class="form-block">
+									<div class="form-block" style="padding-top: 8px">
 										<div class="vz-error-notice notice notice-error hidden"></div>
 										<div class="pb-30">
 											<div class="vz-shortcode-preview-box">
@@ -187,9 +184,12 @@ $last_step_number   = 5;
 													<div class="icon">
 														<img src="<?php echo esc_url( VISUALIZER_ABSURL . 'images/database-icon.png' ); ?>" alt="">
 													</div>
-													<div class="txt">
+													<div class="txt" style="width: 100%;">
 														<h4 class="h4 pb-4"><?php esc_html_e( 'Importing demo data', 'visualizer' ); ?></h4>
-														<p class="p" data-import_message="<?php esc_attr_e( 'Done! Demo data imported successfully', 'visualizer' ); ?>"><?php esc_html_e( 'Hold on! we are importing demo data for your selected chart', 'visualizer' ); ?></p>
+														<p class="p" data-import_message="<?php esc_attr_e( 'Done! Demo data imported successfully.', 'visualizer' ); ?>"><?php esc_html_e( 'Hold on! we are importing demo data for your selected chart', 'visualizer' ); ?></p>
+													<div class="vz-progress" style="margin-top: 4px;">
+														<div class="vz-progress-bar" style="width: 100%;"></div>
+													</div>
 													</div>
 												</div>
 											</div>


### PR DESCRIPTION
This is related to what we talked on [Slack](https://vertistudio.slack.com/archives/C06410PC59B/p1708083575148569), about the Loading bar behaviour in Visualizer onboarding.

### How it works now (it takes a lot of time):

https://github.com/Codeinwp/visualizer/assets/52494172/ff3eb4f6-86ac-498e-b366-584882153511




### The updated UI:
https://github.com/Codeinwp/visualizer/assets/52494172/97866eed-ab28-4ff1-9a95-a31973736c51




The new way of loading is **faster**, **goes from left to right and disappears when done** (this should allow the user to focus on the continue button and the upsell notice, instead of the loading bar).

___

Closes #1085 