### PR TITLE
fix: missing `customcss` property of chart settings created by wizard

### DIFF
--- a/classes/Visualizer/Module/Wizard.php
+++ b/classes/Visualizer/Module/Wizard.php
@@ -341,6 +341,43 @@ class Visualizer_Module_Wizard extends Visualizer_Module {
 							'min' => '',
 						),
 					),
+					'customcss' => array(
+						'headerRow' => array(
+							'background-color' => '',
+							'color' => '',
+							'transform' => '',
+						),
+						'tableRow' => array(
+							'background-color' => '',
+							'color' => '',
+							'transform' => '',
+						),
+						'oddTableRow' => array(
+							'background-color' => '',
+							'color' => '',
+							'transform' => '',
+						),
+						'selectedTableRow' => array(
+							'background-color' => '',
+							'color' => '',
+							'transform' => '',
+						),
+						'hoverTableRow' => array(
+							'background-color' => '',
+							'color' => '',
+							'transform' => '',
+						),
+						'headerCell' => array(
+							'background-color' => '',
+							'color' => '',
+							'transform' => '',
+						),
+						'tableCell' => array(
+							'background-color' => '',
+							'color' => '',
+							'transform' => '',
+						),
+					),
 				)
 			);
 			$wizard_data = array(


### PR DESCRIPTION
Close #1082 

## Summary

Added missing `customcss` property for charts settings created by Wizard. Without it, the `Advanced Options` tab will crash because of an undefined variable.

## Testing

1. Create a chart via setup-wizard.
2. After creating the draft page, select the visualizer block.
3. On the Sidebar, press on the `Advanced Options` tab.