### PR TITLE
Add NPS survey

### DIFF
--- a/classes/Visualizer/Module/Admin.php
+++ b/classes/Visualizer/Module/Admin.php
@@ -1260,7 +1260,7 @@ class Visualizer_Module_Admin extends Visualizer_Module {
 		$metadata = $this->get_survey_metadata();
 
 		do_action( 'themeisle_sdk_dependency_enqueue_script', 'survey' );
-		wp_enqueue_script( 'visualizer_chart_survey', VISUALIZER_ABSURL . 'js/survey.js', array( $survey_handler ), $metadata['attributes']['version'], true );
+		wp_enqueue_script( 'visualizer_chart_survey', VISUALIZER_ABSURL . 'js/survey.js', array( $survey_handler ), $metadata['attributes']['free_version'], true );
 		wp_localize_script( 'visualizer_chart_survey', 'visualizerSurveyData', $metadata );
 	}
 }

--- a/classes/Visualizer/Module/Admin.php
+++ b/classes/Visualizer/Module/Admin.php
@@ -1193,13 +1193,7 @@ class Visualizer_Module_Admin extends Visualizer_Module {
 	 * @return array The survey metadata.
 	 */
 	private function get_survey_metadata() {
-		$install_date = get_option( 'visualizer_pro_install', false );
-
-		// Fallback to Free version.
-		if ( false === $install_date ) {
-			$install_date = get_option( 'visualizer_install', false );
-		}
-
+		$install_date     = get_option( 'visualizer_install', false );
 		$install_category = 0;
 
 		if ( false !== $install_date ) {

--- a/js/survey.js
+++ b/js/survey.js
@@ -1,0 +1,12 @@
+/**
+ * Initialize the formbricks survey.
+ * 
+ * @see https://github.com/formbricks/setup-examples/tree/main/html
+ */
+window.addEventListener('themeisle:survey:loaded', function () {
+    window?.tsdk_formbricks?.init?.({
+        environmentId: "cltef8cut1s7wyyfxy3rlxzs5",
+        apiHost: "https://app.formbricks.com",
+        ...(window?.visualizerSurveyData ?? {}),
+    });
+});


### PR DESCRIPTION
Closes https://github.com/Codeinwp/visualizer-pro/issues/417

## Summary

Added NPS survey

## Testing

1. Go to Chart Library or Support page under Visualizer admin menu.
2. After a short period, an NPS survey will pop up on the right corner of the viewport.

With Browser DevTools, you can check if the deps are loaded.

<img width="973" alt="Screenshot 2024-03-06 at 17 05 26" src="https://github.com/Codeinwp/visualizer/assets/17597852/d24ad351-ea86-4b19-8302-631856ab4059">

<img width="779" alt="Screenshot 2024-03-06 at 17 05 01" src="https://github.com/Codeinwp/visualizer/assets/17597852/45e77f12-f58d-4f3a-8086-f3ab551201c0">
