### PR TITLE
fix: e2e tests in pro version Codeinwp/visualizer-pro#418

### DIFF
--- a/classes/Visualizer/Render/Layout.php
+++ b/classes/Visualizer/Render/Layout.php
@@ -925,7 +925,6 @@ class Visualizer_Render_Layout extends Visualizer_Render {
 
 											<input type="button" id="filter-chart-button" class="button button-secondary show-chart-toggle" value="<?php echo $bttn_label; ?>" data-current="chart" data-t-filter="<?php _e( 'Show Chart', 'visualizer' ); ?>" data-t-chart="<?php echo $bttn_label; ?>">
 											<input type="button" id="db-filter-save-button" class="button button-primary" value="<?php _e( 'Save Schedule', 'visualizer' ); ?>">
-											<?php echo apply_filters( 'visualizer_pro_upsell', '', 'db-query' ); ?>
 										</form>
 										<?php echo apply_filters( 'visualizer_pro_upsell', '', 'import-wp' ); ?>
 									</div>

--- a/classes/Visualizer/Render/Layout.php
+++ b/classes/Visualizer/Render/Layout.php
@@ -872,7 +872,11 @@ class Visualizer_Render_Layout extends Visualizer_Render {
 										<input type="button" id="existing-chart" class="button button-primary"
 											   value="<?php _e( 'Import Chart', 'visualizer' ); ?>"
 											   data-viz-link="<?php echo $fetch_link; ?>">
-										<?php echo apply_filters( 'visualizer_pro_upsell', '', 'import-chart' ); ?>
+										<?php
+										if ( ! Visualizer_Module_Admin::proFeaturesLocked() ) {
+											echo apply_filters( 'visualizer_pro_upsell', '', 'import-chart' );
+										}
+										?>
 									</div>
 								</div>
 							</li>

--- a/cypress/integration/default/free-upsell.js
+++ b/cypress/integration/default/free-upsell.js
@@ -8,11 +8,13 @@ describe('Test Free - upsells', function() {
         cy.get('#wp-submit').click();
     });
 
-    it('Check upsell links', function() {
+    beforeEach(() => {
         cy.visit(Cypress.env('urls').library );
-        cy.get('.visualizer-chart > .visualizer-chart-canvas > .visualizer-notfound > h2 > .add-new-h2').click()
+        cy.get('.add-new-h2.add-new-chart').first().click();
         cy.wait( Cypress.env('wait') );
+    });
 
+    it('Check upsell links', function() {
         cy.get('iframe')
             .then(function ($iframe) {
                 const $body = $iframe.contents().find('body');
@@ -74,10 +76,6 @@ describe('Test Free - upsells', function() {
     });
 
     it('Check Settings upsell links', function() {
-        cy.visit(Cypress.env('urls').library );
-        cy.get('.visualizer-chart > .visualizer-chart-canvas > .visualizer-notfound > h2 > .add-new-h2').click()
-        cy.wait( Cypress.env('wait') );
-
         cy.get('iframe')
             .then(function ($iframe) {
                 const $body = $iframe.contents().find('body');

--- a/cypress/integration/default/free-upsell.js
+++ b/cypress/integration/default/free-upsell.js
@@ -1,0 +1,134 @@
+describe('Test Free - upsells', function() {
+    before(function () {
+
+        // login to WP
+        cy.visit('wp-login.php');
+        cy.get('#user_login').clear().type(Cypress.env('login'));
+        cy.get('#user_pass').clear().type(Cypress.env('pass'));
+        cy.get('#wp-submit').click();
+    });
+
+    it('Check upsell links', function() {
+        cy.visit(Cypress.env('urls').library );
+        cy.get('.visualizer-chart > .visualizer-chart-canvas > .visualizer-notfound > h2 > .add-new-h2').click()
+        cy.wait( Cypress.env('wait') );
+
+        cy.get('iframe')
+            .then(function ($iframe) {
+                const $body = $iframe.contents().find('body');
+                cy.wrap($body).find('#toolbar input[type="submit"]').click();
+                cy.wait( Cypress.env('wait') );
+            });
+
+        cy.get('iframe')
+            .then(function ($iframe) {
+                const $body = $iframe.contents().find('body');
+                // Check Import form other chart upsell.
+                const other_import = cy.wrap($body).find('.viz-import-from-other');
+                other_import.click();
+                other_import.should('have.class', 'only-pro-feature');
+                const other_import_upsell_url = cy.wrap($body).find('.viz-import-from-other .viz-group-content .only-pro-content .only-pro-container .only-pro-inner a').should('have.attr', 'href').then((href) => {
+                    const other_import_search_params = new URLSearchParams(href);
+                    expect(other_import_search_params.get('utm_campaign')).to.equal('import-chart');
+                });
+            });
+
+        cy.get('iframe')
+            .then(function ($iframe) {
+                const $body = $iframe.contents().find('body');
+                // Check import form WordPress upsell.
+                const wp_import = cy.wrap($body).find('.visualizer_source_query_wp');
+                wp_import.click();
+                wp_import.should('have.class', 'only-pro-feature');
+                const wp_import_upsell_url = cy.wrap($body).find('.visualizer_source_query_wp .viz-group-content .only-pro-content .only-pro-container .only-pro-inner a').should('have.attr', 'href').then((href) => {
+                    const wp_import_search_params = new URLSearchParams(href);
+                    expect(wp_import_search_params.get('utm_campaign')).to.equal('import-wp');
+                });
+            });
+
+        cy.get('iframe')
+            .then(function ($iframe) {
+                const $body = $iframe.contents().find('body');
+                // Check import form database upsell.
+                const db_import = cy.wrap($body).find('.visualizer_source_query');
+                db_import.click();
+                db_import.should('have.class', 'only-pro-feature');
+                const db_import_upsell_url = cy.wrap($body).find('.visualizer_source_query .viz-group-content .only-pro-content .only-pro-container .only-pro-inner a').should('have.attr', 'href').then((href) => {
+                    const db_import_search_params = new URLSearchParams(href);
+                    expect(db_import_search_params.get('utm_campaign')).to.equal('db-query');
+                });
+            });
+
+        cy.get('iframe')
+            .then(function ($iframe) {
+                const $body = $iframe.contents().find('body');
+                // Check import form manual data upsell.
+                const manual_import = cy.wrap($body).find('.visualizer_source_manual');
+                manual_import.click();
+                manual_import.should('have.class', 'only-pro-feature');
+                const manual_import_upsell_url = cy.wrap($body).find('.visualizer_source_manual .viz-group-content .only-pro-content .only-pro-container .only-pro-inner a').should('have.attr', 'href').then((href) => {
+                    const manual_import_search_params = new URLSearchParams(href);
+                    expect(manual_import_search_params.get('utm_campaign')).to.equal('manual-data');
+                });
+            });
+    });
+
+    it('Check Settings upsell links', function() {
+        cy.visit(Cypress.env('urls').library );
+        cy.get('.visualizer-chart > .visualizer-chart-canvas > .visualizer-notfound > h2 > .add-new-h2').click()
+        cy.wait( Cypress.env('wait') );
+
+        cy.get('iframe')
+            .then(function ($iframe) {
+                const $body = $iframe.contents().find('body');
+                cy.wrap($body).find('#toolbar input[type="submit"]').click();
+                cy.wait( Cypress.env('wait') );
+            });
+
+        cy.get('iframe')
+            .then(function ($iframe) {
+                const $body = $iframe.contents().find('body');
+                cy.wrap($body).find('#viz-tab-advanced').click();
+                cy.wait( Cypress.env('wait') );
+            });
+
+        cy.get('iframe')
+            .then(function ($iframe) {
+                const $body = $iframe.contents().find('body');
+                // Check setting chart data filter configuration upsell.
+                const data_control = cy.wrap($body).find('#vz-data-controls');
+                data_control.click();
+                data_control.should('have.class', 'only-pro-feature');
+                const data_control_upsell_url = cy.wrap($body).find('#vz-data-controls .viz-group-content .only-pro-content .only-pro-container .only-pro-inner a').should('have.attr', 'href').then((href) => {
+                    const data_control_search_params = new URLSearchParams(href);
+                    expect(data_control_search_params.get('utm_campaign')).to.equal('data-filter-configuration');
+                });
+            });
+
+        cy.get('iframe')
+            .then(function ($iframe) {
+                const $body = $iframe.contents().find('body');
+                // Check setting frontend actions upsell.
+                const frontend_actions = cy.wrap($body).find('#vz-frontend-actions');
+                frontend_actions.click();
+                frontend_actions.should('have.class', 'only-pro-feature');
+                const frontend_actions_upsell_url = cy.wrap($body).find('#vz-frontend-actions .viz-group-content .only-pro-content .only-pro-container .only-pro-inner a').should('have.attr', 'href').then((href) => {
+                    const frontend_actions_search_params = new URLSearchParams(href);
+                    expect(frontend_actions_search_params.get('utm_campaign')).to.equal('frontend-actions');
+                });
+            });
+
+        cy.get('iframe')
+            .then(function ($iframe) {
+                const $body = $iframe.contents().find('body');
+                // Check setting permissions upsell.
+                const permissions = cy.wrap($body).find('#vz-permissions');
+                permissions.click();
+                permissions.should('have.class', 'only-pro-feature');
+                const permissions_upsell_url = cy.wrap($body).find('#vz-permissions .viz-group-content .only-pro-content .only-pro-container .only-pro-inner a').should('have.attr', 'href').then((href) => {
+                    const permissions_search_params = new URLSearchParams(href);
+                    expect(permissions_search_params.get('utm_campaign')).to.equal('chart-permissions');
+                });
+            });
+    });
+});


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Improved the filter conditions so that only one upsell is present for each category and that the upsell is not present when the pro plugin is active.

Added e2e tests for all upsells using the filter.


> [!NOTE]  
> Once this is merged into `development` the e2e tests from the PRO version should also pass.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Check that all upsells work as before.
2. Check that the e2e pass.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes Codeinwp/visualizer-pro#418.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
