### PR TITLE
Stop auto-redirect in Preview

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://playground.wordpress.net/blueprint-schema.json",
-    "landingPage": "/wp-admin/admin.php?page=visualizer-setup-wizard&env=preview",
+    "landingPage": "\/wp-admin\/admin.php?page=visualizer-setup-wizard&env=preview",
     "preferredVersions": {
         "php": "8.0",
         "wp": "latest"
@@ -23,6 +23,10 @@
             "options": {
                 "activate": true
             }
+        },
+        {
+            "step": "wp-cli",
+            "command": "wp option update visualizer_fresh_install 1"
         }
     ]
 }

--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -10,6 +10,10 @@
     },
     "steps": [
         {
+            "step": "wp-cli",
+            "command": "wp option update visualizer_fresh_install 1"
+        },
+        {
             "step": "login",
             "username": "admin",
             "password": "password"
@@ -23,10 +27,6 @@
             "options": {
                 "activate": true
             }
-        },
-        {
-            "step": "wp-cli",
-            "command": "wp option update visualizer_fresh_install 1"
         }
     ]
 }

--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://playground.wordpress.net/blueprint-schema.json",
-    "landingPage": "\/wp-admin\/admin.php?page=visualizer-setup-wizard&env=preview",
+    "landingPage": "\/wp-admin\/admin.php?page=visualizer-setup-wizard&env=preview&tab#step-1",
     "preferredVersions": {
         "php": "8.0",
         "wp": "latest"

--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -10,15 +10,6 @@
     },
     "steps": [
         {
-            "step": "wp-cli",
-            "command": "wp option update visualizer_fresh_install 1"
-        },
-        {
-            "step": "login",
-            "username": "admin",
-            "password": "password"
-        },
-        {
             "step": "installPlugin",
             "pluginZipFile": {
                 "resource": "wordpress.org/plugins",
@@ -27,6 +18,19 @@
             "options": {
                 "activate": true
             }
+        },
+        {
+            "step": "wp-cli",
+            "command": "wp option update visualizer_fresh_install 1"
+        },
+        {
+            "step": "wp-cli",
+            "command": "wp option delete visualizer-activated"
+        },
+        {
+            "step": "login",
+            "username": "admin",
+            "password": "password"
         }
     ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -436,3 +436,6 @@ Examples:
 
 > [!NOTE]
 > Make sure to respect the [schema](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/playground/blueprints/public/blueprint-schema.json). You can validate your blueprint using a schema validator: [online](https://www.jsonschemavalidator.net/), [CLI](https://ajv.js.org/packages/ajv-cli.html)
+
+> [!NOTE]
+> To test the blueprint, you can publish the branch and append the `blueprint.json` path to the URL: `https://playground.wordpress.net/?plugin=visualizer&blueprint-url=`. [Example](https://playground.wordpress.net/?plugin=visualizer&blueprint-url=https://raw.githubusercontent.com/Codeinwp/visualizer/fix/blueprint-redirect/.wordpress-org/blueprints/blueprint.json).


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Blueprint changes
- enhance the landing page link
- stop the auto-redirect via `visualizer-activated`
- hide the normal wizard submenu page via `visualizer_fresh_install`

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

<img width="1760" alt="Screenshot 2024-03-29 at 12 27 07" src="https://github.com/Codeinwp/visualizer/assets/17597852/42bee45f-e00e-44f6-8d07-b84bb32ca19a">

### Test instructions
<!-- Describe how this pull request can be tested. -->

Enter on this link https://playground.wordpress.net/?plugin=visualizer&blueprint-url=https://raw.githubusercontent.com/Codeinwp/visualizer/fix/blueprint-redirect/.wordpress-org/blueprints/blueprint.json

You should see only three steps. 

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/visualizer/issues/1095
<!-- Should look like this: `Closes #1, #2, #3.` . -->
