### PR TITLE
Fix/sql data admin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ cypress.env.json
 /cypress/videos/
 /cypress/screenshots/
 artifacts
+.phpunit.result.cache

--- a/classes/Visualizer/Module/Chart.php
+++ b/classes/Visualizer/Module/Chart.php
@@ -1421,7 +1421,7 @@ class Visualizer_Module_Chart extends Visualizer_Module {
 	public function getQueryData() {
 		check_ajax_referer( Visualizer_Plugin::ACTION_FETCH_DB_DATA . Visualizer_Plugin::VERSION, 'security' );
 
-		if ( ! current_user_can( 'edit_posts' ) ) {
+		if ( ! current_user_can( 'manage_options' ) ) {
 			wp_send_json_error( array( 'msg' => __( 'Action not allowed for this user.', 'visualizer' ) ) );
 		}
 

--- a/classes/Visualizer/Module/Chart.php
+++ b/classes/Visualizer/Module/Chart.php
@@ -1421,7 +1421,7 @@ class Visualizer_Module_Chart extends Visualizer_Module {
 	public function getQueryData() {
 		check_ajax_referer( Visualizer_Plugin::ACTION_FETCH_DB_DATA . Visualizer_Plugin::VERSION, 'security' );
 
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( 'administrator' ) ) {
 			wp_send_json_error( array( 'msg' => __( 'Action not allowed for this user.', 'visualizer' ) ) );
 		}
 

--- a/classes/Visualizer/Source/Query.php
+++ b/classes/Visualizer/Source/Query.php
@@ -85,6 +85,42 @@ class Visualizer_Source_Query extends Visualizer_Source {
 			return false;
 		}
 
+		// if previous check passed, check for disallowed query parts to prevent subqueries and other harmful queries.
+		$disallow_query_parts = array(
+			'INSERT',
+			'UPDATE',
+			'DELETE',
+			'RENAME',
+			'DROP',
+			'CREATE',
+			'TRUNCATE',
+			'ALTER',
+			'COMMIT',
+			'ROLLBACK',
+			'MERGE',
+			'CALL',
+			'EXPLAIN',
+			'LOCK',
+			'GRANT',
+			'REVOKE',
+			'SAVEPOINT',
+			'TRANSACTION',
+			'SET',
+		);
+		$disallow_regex = implode(
+			'|',
+			array_map(
+				function ( $value ) {
+					return '\b' . $value . '\b';
+				}, $disallow_query_parts
+			)
+		);
+
+		if ( preg_match( '/(' . $disallow_regex . ')/i', $this->_query) !== 0 ) {
+			$this->_error = __( 'Only SELECT queries are allowed', 'visualizer' );
+			return false;
+		}
+
 		// impose a limit if no limit clause is provided.
 		if ( strpos( strtolower( $this->_query ), ' limit ' ) === false ) {
 			$this->_query   .= ' LIMIT ' . apply_filters( 'visualizer_sql_query_limit', 1000, $this->_chart_id );

--- a/classes/Visualizer/Source/Query.php
+++ b/classes/Visualizer/Source/Query.php
@@ -80,7 +80,7 @@ class Visualizer_Source_Query extends Visualizer_Source {
 		}
 
 		// only select queries allowed.
-		if ( preg_match( '/\s*(\binsert\b|\bdelete\b|\bupdate\b|\breplace\b|\bcreate\b|\balter\b|\bdrop\b|\btruncate\b)\s/i', $this->_query ) ) {
+		if ( ! preg_match( '/\s*(\bselect\b)\s/i', $this->_query ) ) {
 			$this->_error = __( 'Only SELECT queries are allowed', 'visualizer' );
 			return false;
 		}

--- a/tests/test-ajax.php
+++ b/tests/test-ajax.php
@@ -30,7 +30,7 @@ class Test_Visualizer_Ajax extends WP_Ajax_UnitTestCase {
 	/**
 	 * Set up.
 	 */
-	public function setUp(): void {
+	public function setUp() {
 		parent::setUp();
 		$this->admin_user_id = $this->factory->user->create(
 			array(

--- a/tests/test-ajax.php
+++ b/tests/test-ajax.php
@@ -21,9 +21,16 @@ class Test_Visualizer_Ajax extends WP_Ajax_UnitTestCase {
 	private $admin_user_id;
 
 	/**
+	 * Subscriber user ID.
+	 *
+	 * @var int
+	 */
+	private $subscriber_user_id;
+
+	/**
 	 * Set up.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 		$this->admin_user_id = $this->factory->user->create(
 			array(
@@ -31,6 +38,12 @@ class Test_Visualizer_Ajax extends WP_Ajax_UnitTestCase {
 			)
 		);
 		wp_set_current_user( $this->admin_user_id );
+
+		$this->subscriber_user_id = $this->factory->user->create(
+			array(
+				'role' => 'subscriber',
+			)
+		);
 
 	}
 
@@ -117,6 +130,7 @@ class Test_Visualizer_Ajax extends WP_Ajax_UnitTestCase {
 	 * Test the AJAX response for fetching the database data with user capability.
 	 */
 	public function test_ajax_response_get_query_data_subcriber_dissallow() {
+		wp_set_current_user( $this->subscriber_user_id );
 		$this->_setRole( 'subscriber' );
 
 		$_GET['security'] = wp_create_nonce( Visualizer_Plugin::ACTION_FETCH_DB_DATA . Visualizer_Plugin::VERSION );


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Restricted the SQL Data to only admin users.
Changed the list from a deny to an allow for the SQL filter.
Changed the unit test.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Check the linked issue for testing details
2. All tests should pass.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes Codeinwp/visualizer-pro#433.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
