### PR TITLE
fix: remove database from personal plan

### DIFF
--- a/classes/Visualizer/Module.php
+++ b/classes/Visualizer/Module.php
@@ -740,9 +740,9 @@ class Visualizer_Module {
 	public static final function get_features_for_license( $plan ) {
 		switch ( $plan ) {
 			case 1:
-				return array( 'import-wp', 'db-query', 'import-wc-report', 'import-file', 'import-url' );
+				return array( 'import-wp', 'import-wc-report', 'import-file', 'import-url' );
 			case 2:
-				return array( 'schedule-chart', 'chart-permissions', 'import-chart', 'data-filter-configuration', 'frontend-actions' );
+				return array( 'db-query', 'schedule-chart', 'chart-permissions', 'import-chart', 'data-filter-configuration', 'frontend-actions' );
 		}
 	}
 

--- a/classes/Visualizer/Module/Sources.php
+++ b/classes/Visualizer/Module/Sources.php
@@ -139,8 +139,8 @@ class Visualizer_Module_Sources extends Visualizer_Module {
 			( in_array( $feature, $pro_features, true ) && ! Visualizer_Module::is_pro() )
 		) {
 			$msg = sprintf( __( 'Upgrade to %s to activate this feature!', 'visualizer' ), 'PRO' );
-			if ( Visualizer_Module::is_pro() && in_array( $feature, $biz_features, true ) ) {
-				$msg = sprintf( __( 'Upgrade your license to at least the %s version to activate this feature!', 'visualizer' ), 'DEVELOPER' );
+			if ( in_array( $feature, $biz_features, true ) ) {
+				$msg = sprintf( __( 'Upgrade to %s plan to activate this feature!', 'visualizer' ), 'Developer' );
 			}
 			$return = '<div class="only-pro-content">';
 			$return .= '	<div class="only-pro-container">';

--- a/tests/e2e/specs/upsell.spec.js
+++ b/tests/e2e/specs/upsell.spec.js
@@ -21,9 +21,9 @@ test.describe( 'Upsell', () => {
         await page.waitForSelector('h1:text("Visualizer")');
 
         expect( await page.frameLocator('iframe').locator('.pro-upsell').count() ).toBe( 11 );
-       
+
         const proUpsellElements = await page.frameLocator('iframe').locator('a.pro-upsell').all();
-        
+
         for (const element of proUpsellElements) {
             const href = await element.getAttribute('href');
             const searchParams = new URLSearchParams(href);
@@ -61,11 +61,17 @@ test.describe( 'Upsell', () => {
         href = await wpImportUpsell.getAttribute('href');
         searchParams = new URLSearchParams(href);
         expect( searchParams.get('utm_campaign') ).toBe('import-wp');
+        await page.frameLocator('iframe').getByRole('heading', { name: /Import from WordPress/ }).click();
+        await expect(page.frameLocator('iframe').locator('#vz-chart-source')).toContainText('Upgrade to PRO to activate this feature!');
 
         const dbImportUpsell = page.frameLocator('iframe').locator('#vz-chart-source .visualizer_source_query .only-pro-inner a');
         href = await dbImportUpsell.getAttribute('href');
         searchParams = new URLSearchParams(href);
         expect( searchParams.get('utm_campaign') ).toBe('db-query');
+
+        await page.frameLocator('iframe').getByRole('heading', { name: /Import from database/ }).click();
+        await expect(page.frameLocator('iframe').locator('#vz-db-wizard')).toContainText('Upgrade to Developer plan to activate this feature!');
+        await expect(page.frameLocator('iframe').locator('#vz-db-wizard')).toContainText('Upgrade Now');
 
         await page.frameLocator('iframe').getByRole('link', { name: 'Settings' }).click();
 
@@ -83,6 +89,9 @@ test.describe( 'Upsell', () => {
         href = await chartPermissionsUpsell.getAttribute('href');
         searchParams = new URLSearchParams(href);
         expect( searchParams.get('utm_campaign') ).toBe('chart-permissions');
+        await page.frameLocator('iframe').getByRole('heading', { name: /Permissions/ }).click();
+        await expect(page.frameLocator('iframe').locator('#vz-db-wizard')).toContainText('Upgrade to Developer plan to activate this feature!');
+        await expect(page.frameLocator('iframe').locator('#vz-db-wizard')).toContainText('Upgrade Now');
     });
 
     test( 'featured tab in Install Plugin (SDK)', async ( { admin, page } ) => {


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Remove the database source option from the Personal plan.
Change the upsell message when an upgrade to the Developer plan is required.
Added E2E test to check this behavior.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->
<details open>
    <summary>Personal Plan</summary>

![image](https://github.com/Codeinwp/visualizer/assets/23024731/69b53bf7-3af3-407c-97a2-8d2835744d49)
</details>

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. E2E tests should pass
2. On a fresh instance activate VIsualizer PRO with a Personal License
3. Check that the Import from database option is not available and asks for an upgrade to the Developer plan.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes Codeinwp/visualizer-pro#458.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
