### PR TITLE
fix: remove lazy from shortcode

### DIFF
--- a/classes/Visualizer/Render/Library.php
+++ b/classes/Visualizer/Render/Library.php
@@ -343,7 +343,7 @@ class Visualizer_Render_Library extends Visualizer_Render {
 			$chart_status['icon'] = 'error dashicons-dismiss';
 			$chart_status['title'] = __( 'Click to view the error', 'visualizer' );
 		}
-		$shortcode = sprintf( '[visualizer id="%s" lazy="no" class=""]', $chart_id );
+		$shortcode = sprintf( '[visualizer id="%s" class=""]', $chart_id );
 		echo '<div class="items"><div class="visualizer-chart"><div class="visualizer-chart-title">', esc_html( $title ), '</div>';
 		if ( Visualizer_Module::is_pro() && $with_filter ) {
 			echo '<div id="chart_wrapper_' . $placeholder_id . '">';

--- a/tests/e2e/playwright.config.js
+++ b/tests/e2e/playwright.config.js
@@ -24,7 +24,7 @@ const config = defineConfig( {
 	projects: [
 		{
 			name: 'chromium',
-			use: { ...devices[ 'Desktop Chrome' ] },
+			use: { ...devices[ 'Desktop Chrome' ], permissions: ["clipboard-read"] },
 			grepInvert: /-chromium/,
 		},
 		// {

--- a/tests/e2e/specs/admin.spec.js
+++ b/tests/e2e/specs/admin.spec.js
@@ -19,9 +19,9 @@ test.describe( 'Chart Library', () => {
     test( 'check Add New button', async ( { page} ) => {
         await expect(page.getByRole('heading', { name: 'Visualizer Library Add New' }).getByRole('link')).toBeVisible();
     } );
-    
+
     test( 'check filters options', async ( { page } ) => {
-        
+
         // CHART TYPE FILTER
         await expect( page.locator('select[name="type"]') ).toBeVisible();
         await expect( page.locator('select[name="type"] option').count() ).resolves.toBe( 15 + 1 );
@@ -33,7 +33,7 @@ test.describe( 'Chart Library', () => {
         for (const option of libraryOptions) {
             await expect( page.locator('select[name="library"] option').filter({ hasText: option }).count() ).resolves.toBe( 1 );
         }
-        
+
         // DATE FILTER
         const dateOptions = ['Yesterday', 'Last Week', 'Last Month', 'Last Year', 'All dates'];
         await expect( page.locator('select[name="date"]') ).toBeVisible();
@@ -41,7 +41,7 @@ test.describe( 'Chart Library', () => {
         for (const option of dateOptions) {
             await expect( page.locator('select[name="date"] option').filter({ hasText: option }).count() ).resolves.toBe( 1 );
         }
-        
+
         // SOURCES FILTER
         const sourcesOptions = ['All sources', 'Database', 'JSON', 'Local CSV', 'Remote CSV', 'WordPress'];
         await expect( page.locator('select[name="source"]') ).toBeVisible();
@@ -78,6 +78,14 @@ test.describe( 'Chart Library', () => {
         const chartId = await createChartWithAdmin( admin, page );
         await admin.visitAdminPage( 'admin.php?page=visualizer' );
         await expect( page.locator(`#visualizer-${chartId}`).count() ).resolves.toBeGreaterThan( 0 );
+
+        // Check shortcode generated.
+        const chartContainer = page.locator(`.visualizer-chart`, { has: page.locator(`#visualizer-${chartId}`) });
+        expect( chartContainer ).toBeVisible();
+        await chartContainer.locator('a.visualizer-chart-shortcode').click();
+        let shortcodeClipboard = await page.evaluate("navigator.clipboard.readText()");
+        expect(shortcodeClipboard).toMatch(/\[visualizer\sid="\d+"\sclass=""]/);
+
     } );
 
     test('clone/duplicate a chart', async ( { page, admin } ) => {
@@ -86,7 +94,7 @@ test.describe( 'Chart Library', () => {
 
         // Count the current charts, then compare after cloning.
         const chartsCount = await page.locator('.visualizer-chart').count();
-        
+
         // Select the chart and clone it.
         const chartContainer = page.locator(`.visualizer-chart`, { has: page.locator(`#visualizer-${chartId}`) });
         expect( chartContainer ).toBeVisible();
@@ -94,24 +102,24 @@ test.describe( 'Chart Library', () => {
 
         await waitForLibraryToLoad( page );
         const newChartsCount = await page.locator('.visualizer-chart').count();
-        
+
         expect( newChartsCount ).toBeGreaterThan( chartsCount );
     } );
 
     test('delete a chart', async ( { page, admin } ) => {
         const chartId = await createChartWithAdmin( admin, page );
         await admin.visitAdminPage( 'admin.php?page=visualizer' );
-        
+
         await expect( page.locator(`#visualizer-${chartId}`).count() ).resolves.toBeGreaterThan( 0 );
 
         // Accept the dialog to delete the chart.
         page.on('dialog', dialog => dialog.accept());
-        
+
         // Select the chart and delete it.
         const chartContainer = page.locator(`.visualizer-chart`, { has: page.locator(`#visualizer-${chartId}`) });
         expect( chartContainer ).toBeVisible();
         await chartContainer.locator('a.visualizer-chart-delete').click({ timeout: 5000 });
-        
+
         await waitForLibraryToLoad( page );
         await expect( page.locator(`#visualizer-${chartId}`).count() ).resolves.toBe( 0 );
     } );
@@ -130,12 +138,12 @@ test.describe( 'Chart Library', () => {
         await admin.visitAdminPage( 'admin.php?page=visualizer&vaction=addnew' );
         await page.waitForURL( '**/admin.php?page=visualizer&vaction=addnew' );
         await page.waitForSelector('h1:text("Visualizer")');
-        
+
         await selectChartAdmin( page.frameLocator('iframe'), CHART_JS_LABELS.table );
 
         await page.frameLocator('iframe').getByRole('button', { name: 'Skip' }).click();
         await waitForLibraryToLoad( page );
-       
+
         // The Create Chart button should be not exists since we skipped the second step.
         expect( page.frameLocator('iframe').getByRole('button', { name: 'Create Chart' }) ).toBeHidden();
     } );


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Updated generated shortcode.
Added E2E test.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Tests should pass.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes Codeinwp/visualizer-pro#462.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
