### PR TITLE
feat: add backend title for charts

### DIFF
--- a/classes/Visualizer/Render/Layout.php
+++ b/classes/Visualizer/Render/Layout.php
@@ -590,7 +590,12 @@ class Visualizer_Render_Layout extends Visualizer_Render {
 	 * @access public
 	 */
 	public static function _renderTabAdvanced( $args ) {
-		$sidebar = $args[2];
+		$chart_id = $args[1];
+		$sidebar  = $args[2];
+
+		$chart_options = get_post_meta( $chart_id, Visualizer_Plugin::CF_SETTINGS, true );
+		$backend_title = isset( $chart_options['backend-title'] ) && ! empty( $chart_options['backend-title'] ) ? $chart_options['backend-title'] : '';
+
 		?>
 			<ul class="viz-group-wrapper full-height">
 				<li class="viz-group open" id="vz-chart-settings">
@@ -598,6 +603,7 @@ class Visualizer_Render_Layout extends Visualizer_Render {
 						<ul class="viz-group-wrapper">
 						<form id="settings-form" action="<?php echo esc_url( add_query_arg( 'nonce', wp_create_nonce() ) ); ?>" method="post">
 							<input type="hidden" id="chart-img" name="chart-img">
+							<input type="hidden" id="backend-title" name="backend-title" value="<?php echo esc_html( $backend_title ); ?>">
 							<?php echo $sidebar; ?>
 							<?php self::_renderPermissions( $args ); ?>
 							<input type="hidden" name="save" value="1">

--- a/classes/Visualizer/Render/Library.php
+++ b/classes/Visualizer/Render/Library.php
@@ -301,6 +301,9 @@ class Visualizer_Render_Library extends Visualizer_Render {
 		if ( is_array( $title ) && isset( $title['text'] ) ) {
 			$title = $title['text'];
 		}
+		if ( ! empty( $settings[0]['backend-title'] ) ) {
+			$title  = $settings[0]['backend-title'];
+		}
 		if ( empty( $title ) ) {
 			$title  = '#' . $chart_id;
 		}

--- a/classes/Visualizer/Render/Page/Data.php
+++ b/classes/Visualizer/Render/Page/Data.php
@@ -80,7 +80,7 @@ class Visualizer_Render_Page_Data extends Visualizer_Render_Page {
 	protected function _renderSidebarContent() {
 
 		$chartSettings = get_post_meta( $this->chart->ID, Visualizer_Plugin::CF_SETTINGS, true );
-		$hasTitle = isset( $chartSettings['title'] ) && '' !== $chartSettings['title'];
+		$hasTitle = isset( $chartSettings['backend-title'] ) && '' !== $chartSettings['backend-title'];
 
 		?>
 		<div class="viz-info-panel">
@@ -92,8 +92,8 @@ class Visualizer_Render_Page_Data extends Visualizer_Render_Page {
 				</div>
 			</div>
 			<div class="viz-info-item">
-				<label for="viz-internal-name"><?php _e( 'Backend chart title for internal usage', 'visualizer' ); ?></label>
-				<input type="text" id="viz-internal-name" value="<?php echo  $hasTitle ? $chartSettings['title'] : ( '#' . esc_attr( $this->chart->ID ) ); ?>">
+				<label for="viz-backend-name"><?php _e( 'Backend chart title for internal usage', 'visualizer' ); ?></label>
+				<input type="text" id="viz-backend-name" value="<?php echo  $hasTitle ? $chartSettings['backend-title'] : ( '#' . esc_attr( $this->chart->ID ) ); ?>">
 			</div>
 		</div>
 		<div id="viz-tabs">

--- a/js/frame.js
+++ b/js/frame.js
@@ -692,16 +692,12 @@ document.querySelector('#viz-copy-shortcode')?.addEventListener('click', functio
     alert(visualizer.l10n.copied);
 });
 
-// Create a two way sync between Chart Title Info Panel and Setting Chart Title.
-const internalTitle = document.querySelector( '#viz-internal-name' );
-const formChartTile = document.querySelector( '#settings-form input[name="title"]' );
+// Connect Chart Backend Title Info Panel with the field from the settings form.
+const interactiveBackendTitleField = document.querySelector( '#viz-backend-name' );
+const backendTitleSave = document.querySelector( '#settings-form input[name="backend-title"]' );
 
-if ( internalTitle && formChartTile ) {
-    internalTitle.addEventListener('input', function() {
-        formChartTile.value = this.value;
-    });
-
-    formChartTile.addEventListener('input', function() {
-        internalTitle.value = this.value;
+if ( interactiveBackendTitleField && backendTitleSave ) {
+    interactiveBackendTitleField.addEventListener('input', function() {
+        backendTitleSave.value = this.value;
     });
 }

--- a/tests/e2e/specs/admin.spec.js
+++ b/tests/e2e/specs/admin.spec.js
@@ -145,11 +145,11 @@ test.describe( 'Chart Library', () => {
         await page.waitForURL( '**/admin.php?page=visualizer&vaction=addnew' );
         await page.waitForSelector('h1:text("Visualizer")');
         
-        await selectChartAdmin( page.frameLocator('iframe'), CHART_JS_LABELS.table );
+        await selectChartAdmin( page.frameLocator('iframe'), CHART_JS_LABELS.pie );
 
         await expect( page.frameLocator('iframe').locator('#viz-shortcode') ).toBeVisible();
         await expect( page.frameLocator('iframe').getByRole('button', { name: 'Copy' }) ).toBeVisible();
-        await expect( page.frameLocator('iframe').locator('#viz-internal-name') ).toBeVisible();
+        await expect( page.frameLocator('iframe').locator('#viz-backend-name') ).toBeVisible();
         
         // Check if the shortcode is copied to the clipboard.
         const shortcode = await page.frameLocator('iframe').locator('#viz-shortcode').inputValue();
@@ -158,19 +158,26 @@ test.describe( 'Chart Library', () => {
         expect( clipboardValue ).toBe( shortcode );
 
         // Check two-way binding of the internal name.
-        const name1 = 'Test Internal Name 1';
-        const name2 = 'Test Internal Name 2';
+        const backendName = 'Test Backend Name';
+        const chartName   = 'Test Chart Name';
         
-        await page.frameLocator('iframe').locator('#viz-internal-name').fill(name1);
-        const titleValue = await page.frameLocator('iframe').locator('#settings-form input[name="title"]').inputValue();
-        expect( titleValue ).toBe( name1 );
+        await page.frameLocator('iframe').locator('#viz-backend-name').fill(backendName);
+        const titleValue = await page.frameLocator('iframe').locator('#settings-form input[name="backend-title"]').inputValue();
+        expect( titleValue ).toBe( backendName );
 
         await page.frameLocator('iframe').getByRole('link', { name: 'Settings' }).click();
         await page.frameLocator('iframe').getByRole('heading', { name: 'General Settings' }).click();
+        await page.frameLocator('iframe').getByText('Title', { exact: true }).click();
 
-        await page.frameLocator('iframe').locator('input[name="title"]').fill(name2);
-        const internalNameValue = await page.frameLocator('iframe').locator('#viz-internal-name').inputValue();
-        expect( internalNameValue ).toBe( name2 );
+        await page.frameLocator('iframe').locator('input[name="title"]').fill(chartName);
+        const internalNameValue = await page.frameLocator('iframe').locator('#viz-backend-name').inputValue();
+        expect( internalNameValue ).not.toBe( chartName );
+
+        await page.frameLocator('iframe').getByRole('button', { name: 'Create Chart' }).click();
+        await waitForLibraryToLoad( page );
+
+        await expect( page.getByText(backendName) ).toBeVisible();
+        await expect( page.locator('g').filter({ hasText: 'Test Chart Name' }).locator('rect') ).toBeVisible();
     } );
 } );
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Added backend title to the chart settings. (different that chart title)

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

![image](https://github.com/Codeinwp/visualizer/assets/17597852/4d555b84-e8c9-4785-bb5a-287de87780c7)

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Create a chart or edit an existing one
- Modify the backend title. It should not affected the chart title

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [ ] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/visualizer-pro/issues/445
<!-- Should look like this: `Closes #1, #2, #3.` . -->
