### PR TITLE
Fix/new personal upsell

### DIFF
--- a/classes/Visualizer/Module.php
+++ b/classes/Visualizer/Module.php
@@ -738,11 +738,20 @@ class Visualizer_Module {
 	 * Gets the features for the provided license type.
 	 */
 	public static final function get_features_for_license( $plan ) {
+		$is_new_personal = apply_filters( 'visualizer_is_new_personal', false );
 		switch ( $plan ) {
 			case 1:
-				return array( 'import-wp', 'import-wc-report', 'import-file', 'import-url' );
+				$features = array( 'import-wp', 'import-wc-report', 'import-file', 'import-url' );
+				if ( ! $is_new_personal ) {
+					$features[] = 'db-query';
+				}
+				return $features;
 			case 2:
-				return array( 'db-query', 'schedule-chart', 'chart-permissions', 'import-chart', 'data-filter-configuration', 'frontend-actions' );
+				$features = array( 'schedule-chart', 'chart-permissions', 'import-chart', 'data-filter-configuration', 'frontend-actions' );
+				if ( $is_new_personal ) {
+					$features[] = 'db-query';
+				}
+				return $features;
 		}
 	}
 

--- a/classes/Visualizer/Module/Sources.php
+++ b/classes/Visualizer/Module/Sources.php
@@ -139,8 +139,8 @@ class Visualizer_Module_Sources extends Visualizer_Module {
 			( in_array( $feature, $pro_features, true ) && ! Visualizer_Module::is_pro() )
 		) {
 			$msg = sprintf( __( 'Upgrade to %s to activate this feature!', 'visualizer' ), 'PRO' );
-			if ( in_array( $feature, $biz_features, true ) ) {
-				$msg = sprintf( __( 'Upgrade to %s plan to activate this feature!', 'visualizer' ), 'Developer' );
+			if ( in_array( $feature, $biz_features, true ) && Visualizer_Module::is_pro() ) {
+				$msg = sprintf( __( 'Upgrade to %s plan to activate this feature!', 'visualizer' ), 'Plus' );
 			}
 			$return = '<div class="only-pro-content">';
 			$return .= '	<div class="only-pro-container">';

--- a/classes/Visualizer/Module/Sources.php
+++ b/classes/Visualizer/Module/Sources.php
@@ -139,9 +139,14 @@ class Visualizer_Module_Sources extends Visualizer_Module {
 			( in_array( $feature, $pro_features, true ) && ! Visualizer_Module::is_pro() )
 		) {
 			$msg = sprintf( __( 'Upgrade to %s to activate this feature!', 'visualizer' ), 'PRO' );
+			$plus_msg = sprintf( __( 'Upgrade to %s plan to activate this feature!', 'visualizer' ), 'Plus' );
 			if ( in_array( $feature, $biz_features, true ) && Visualizer_Module::is_pro() ) {
-				$msg = sprintf( __( 'Upgrade to %s plan to activate this feature!', 'visualizer' ), 'Plus' );
+				$msg = $plus_msg;
 			}
+			if ( in_array( $feature, [ 'db-query', 'chart-permissions' ], true ) ) {
+				$msg = $plus_msg;
+			}
+
 			$return = '<div class="only-pro-content">';
 			$return .= '	<div class="only-pro-container">';
 			$return .= '		<div class="only-pro-inner">';

--- a/js/frame.js
+++ b/js/frame.js
@@ -8,8 +8,11 @@
 
 (function ($) {
     $(window).on('load', function(){
-        // scroll to the selected chart type.
-        $('#chart-select').scrollIntoView();
+        let chart_select = $('#chart-select');
+        if(chart_select.length > 0){
+            // scroll to the selected chart type.
+            $('#chart-select')[0].scrollIntoView();
+        }
     });
 
     $(document).ready(function () {
@@ -154,7 +157,7 @@
 
     /**
      * Initialize/Update the available chart list based on their supported renderer libraries.
-     * 
+     *
      * @returns {void}
      */
     function init_available_chart_list() {
@@ -172,7 +175,7 @@
         const rendererTypesMapping = JSON.parse( rendererTypesMappingData );
 
         document.querySelectorAll('input.type-radio').forEach( chartTypeRadio => {
-            
+
             // Init the lib based on the default selected chart type.
             if ( chartTypeRadio.checked ) {
                 const chartType = chartTypeRadio.value;
@@ -201,14 +204,14 @@
                 }
             });
         });
-       
+
         // Update the chart list on user interaction.
         rendererSelect.addEventListener('change', (event) => {
             disable_renderer_select_placeholder();
             toggle_renderer_type( event.target.value );
             toggle_chart_types_by_render( event.target.value );
         });
-        
+
     }
 
     /**
@@ -223,9 +226,9 @@
 
     /**
      * Toggle the renderer type class based on the given renderer type.
-     * 
+     *
      * The class is used to style the chart type picker based on the given renderer library.
-     * 
+     *
      * @param {('GoogleCharts' | 'ChartJS' | 'DataTable')} rendererType The renderer type to toggle the class.
      */
     function toggle_renderer_type( rendererType ) {
@@ -233,14 +236,14 @@
         if ( ! typePicker ) {
             return;
         }
-        
+
         typePicker.classList.remove('lib-GoogleCharts', 'lib-ChartJS', 'lib-DataTable');
         typePicker.classList.add(`lib-${rendererType}`);
     }
 
     /**
      * Toggle chart types based on the given renderer type.
-     * 
+     *
      * @param {('GoogleCharts' | 'ChartJS' | 'DataTable')} rendererType The renderer type to filter the chart types.
      */
     function toggle_chart_types_by_render( rendererType ) {
@@ -786,11 +789,11 @@
     if( chartTypes ) {
         document.querySelector('.push-right[type=submit]')?.addEventListener('click', async function (event) {
             if ( typeof window.tiTrk !== 'undefined' ) {
-                event.preventDefault();    
+                event.preventDefault();
                 try {
                     const formData = new FormData(document.querySelector('#viz-types-form'));
                     const savedData = Object.fromEntries(formData);
-                
+
                     tiTrk?.with('visualizer')?.add({
                         feature: 'chart-create',
                         featureComponent: 'saved-data',
@@ -800,7 +803,7 @@
                         },
                         groupId
                     });
-                   
+
                     // Do not make the user to wait too long for the event to be uploaded.
                     const timer = new Promise((resolve) => setTimeout(resolve, 500));
                     await Promise.race([timer, tiTrk?.uploadEvents()]);

--- a/tests/e2e/specs/upsell.spec.js
+++ b/tests/e2e/specs/upsell.spec.js
@@ -70,7 +70,7 @@ test.describe( 'Upsell', () => {
         expect( searchParams.get('utm_campaign') ).toBe('db-query');
 
         await page.frameLocator('iframe').getByRole('heading', { name: /Import from database/ }).click();
-        await expect(page.frameLocator('iframe').locator('#vz-db-wizard')).toContainText('Upgrade to Developer plan to activate this feature!');
+        await expect(page.frameLocator('iframe').locator('#vz-db-wizard')).toContainText('Upgrade to Plus plan to activate this feature!');
         await expect(page.frameLocator('iframe').locator('#vz-db-wizard')).toContainText('Upgrade Now');
 
         await page.frameLocator('iframe').getByRole('link', { name: 'Settings' }).click();
@@ -90,7 +90,7 @@ test.describe( 'Upsell', () => {
         searchParams = new URLSearchParams(href);
         expect( searchParams.get('utm_campaign') ).toBe('chart-permissions');
         await page.frameLocator('iframe').getByRole('heading', { name: /Permissions/ }).click();
-        await expect(page.frameLocator('iframe').locator('#vz-db-wizard')).toContainText('Upgrade to Developer plan to activate this feature!');
+        await expect(page.frameLocator('iframe').locator('#vz-db-wizard')).not.toContainText('Upgrade to Plus plan to activate this feature!');
         await expect(page.frameLocator('iframe').locator('#vz-db-wizard')).toContainText('Upgrade Now');
     });
 

--- a/tests/e2e/specs/upsell.spec.js
+++ b/tests/e2e/specs/upsell.spec.js
@@ -90,7 +90,7 @@ test.describe( 'Upsell', () => {
         searchParams = new URLSearchParams(href);
         expect( searchParams.get('utm_campaign') ).toBe('chart-permissions');
         await page.frameLocator('iframe').getByRole('heading', { name: /Permissions/ }).click();
-        await expect(page.frameLocator('iframe').locator('#vz-db-wizard')).not.toContainText('Upgrade to Plus plan to activate this feature!');
+        await expect(page.frameLocator('iframe').locator('#vz-db-wizard')).toContainText('Upgrade to Plus plan to activate this feature!');
         await expect(page.frameLocator('iframe').locator('#vz-db-wizard')).toContainText('Upgrade Now');
     });
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Fixed a JS error that was reported inside the console when trying to focus the select element.
Upsell the Database option only to New Personal, allow access to old Personal plans
Changed the upsell message from:
`Upgrade to Developer plan to activate this feature!`
to:
`Upgrade to Plus plan to activate this feature!`

For Free users, the message should be:
`Upgrade to Pro to activate this feature!`


### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->
<details>
    <summary>Free Upsells</summary>

![image](https://github.com/Codeinwp/visualizer/assets/23024731/bb38855c-84aa-40dd-b42e-09cf0d6ed12e)

![image](https://github.com/Codeinwp/visualizer/assets/23024731/a6549271-d7fc-46df-b3e8-c207552edb87)

![image](https://github.com/Codeinwp/visualizer/assets/23024731/97701a93-2ce9-42eb-9532-95a5e5380357)

![image](https://github.com/Codeinwp/visualizer/assets/23024731/cd07860a-900b-4932-a6c6-86d6346f8fdf)
</details>

<details>
    <summary>New Personal</summary>

![image](https://github.com/Codeinwp/visualizer/assets/23024731/faf337bb-4c71-451d-a8d7-0b46b286cf1a)
</details>

<details>
    <summary>Old Personal</summary>

![image](https://github.com/Codeinwp/visualizer/assets/23024731/de9f91b1-a7c4-4d80-a448-cac4a800358d)

![image](https://github.com/Codeinwp/visualizer/assets/23024731/bbf102bf-1c9e-46e6-b940-b3f267228d4b)
</details>

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. On a fresh instance install Visualizer
2. Check the Free Upsells messages
3. Activate an Old Personal plan
4. Check that the Database option is available.
5. Activate a New Personal plan
6. Check that the Database option is not available.
7. Check the Upsell message.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes Codeinwp/visualizer-pro#468.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
