### PR TITLE
fix: widgets inside customizer

### DIFF
--- a/classes/Visualizer/Module/Admin.php
+++ b/classes/Visualizer/Module/Admin.php
@@ -333,7 +333,7 @@ class Visualizer_Module_Admin extends Visualizer_Module {
 		global $typenow;
 		global $current_screen;
 
-		if ( post_type_supports( $typenow, 'editor' ) || $current_screen->id === 'widgets' ) {
+		if ( post_type_supports( $typenow, 'editor' ) || $current_screen->id === 'widgets' || $current_screen->id === 'customize' ) {
 			wp_enqueue_style( 'visualizer-media', VISUALIZER_ABSURL . 'css/media.css', array( 'media-views' ), Visualizer_Plugin::VERSION );
 
 			// Load all the assets for the different libraries we support.

--- a/tests/e2e/specs/gutenberg-editor.spec.js
+++ b/tests/e2e/specs/gutenberg-editor.spec.js
@@ -148,4 +148,22 @@ test.describe( 'Charts with Gutenberg Editor', () => {
         await expect(page.locator('rect').first()).toBeVisible();
 
     } );
+
+    test( 'check widgets in the Customizer', async ( { admin, editor, page } ) => {
+        await createChartWithAdmin( admin, page );
+
+        await admin.visitAdminPage( 'customize.php' );
+
+        await page.getByRole('heading', { name: 'Widgets' }).click();
+        await page.getByRole('heading', { name: 'Footer' }).click();
+        await page.getByRole('button', { name: 'Got it' }).click();
+        await page.getByLabel('Document tools').getByLabel('Add block').click();
+        await page.getByPlaceholder('Search', { exact: true }).fill('visualizer');
+        await page.getByRole('option', { name: ' Visualizer Chart' }).click();
+        await page.getByText('Display an existing chart').click();
+        await page.locator('.visualizer-settings__charts-controls').first().click();
+        await expect(page.getByLabel('Block: Visualizer Chart')).toContainText('Visualizer');
+        await expect(page.locator('rect').first()).toBeVisible();
+
+    } );
 } );


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Fixed widget not working in Customizer context.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. On a theme that supports Customizer Widgets
2. Try to add a VIsualizer Chart from the Customizer.
3. All tests should pass.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #1156.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
