### PR TITLE
fix: switch to 10 minutes cron

### DIFF
--- a/classes/Visualizer/Module.php
+++ b/classes/Visualizer/Module.php
@@ -138,7 +138,7 @@ class Visualizer_Module {
 	 *
 	 * @access protected
 	 * @param string $tag The name of the filter to hook the $method to.
-	 * @param type   $method The name of the method to be called when the filter is applied.
+	 * @param string $method The name of the method to be called when the filter is applied.
 	 * @param int    $priority optional. Used to specify the order in which the functions associated with a particular action are executed (default: 10). Lower numbers correspond with earlier execution, and functions with the same priority are executed in the order in which they were added to the action.
 	 * @param int    $accepted_args optional. The number of arguments the function accept (default 1).
 	 * @return Visualizer_Module

--- a/classes/Visualizer/Module/Setup.php
+++ b/classes/Visualizer/Module/Setup.php
@@ -49,6 +49,7 @@ class Visualizer_Module_Setup extends Visualizer_Module {
 
 		$this->_addAction( 'admin_init', 'adminInit' );
 		$this->_addAction( 'init', 'setupCustomPostTypes' );
+		$this->_addFilter( 'cron_schedules', 'custom_cron_schedules' );
 		$this->_addAction( 'plugins_loaded', 'loadTextDomain' );
 		$this->_addFilter( 'visualizer_logger_data', 'getLoggerData' );
 		$this->_addFilter( 'visualizer_get_chart_counts', 'getUsage', 10, 2 );
@@ -209,7 +210,7 @@ class Visualizer_Module_Setup extends Visualizer_Module {
 	 */
 	private function activate_on_site() {
 		wp_clear_scheduled_hook( 'visualizer_schedule_refresh_db' );
-		wp_schedule_event( strtotime( 'midnight' ) - get_option( 'gmt_offset' ) * HOUR_IN_SECONDS, apply_filters( 'visualizer_chart_schedule_interval', 'hourly' ), 'visualizer_schedule_refresh_db' );
+		wp_schedule_event( strtotime( 'midnight' ) - get_option( 'gmt_offset' ) * HOUR_IN_SECONDS, apply_filters( 'visualizer_chart_schedule_interval', 'visualizer_ten_minutes' ), 'visualizer_schedule_refresh_db' );
 		add_option( 'visualizer-activated', true );
 		$is_fresh_install  = get_option( 'visualizer_fresh_install', false );
 		if ( ! defined( 'TI_CYPRESS_TESTING' ) && false === $is_fresh_install ) {
@@ -281,9 +282,9 @@ class Visualizer_Module_Setup extends Visualizer_Module {
 	/**
 	 * Refresh the specific chart from the db.
 	 *
-	 * @param WP_Post $chart The chart object.
-	 * @param int     $chart_id The chart id.
-	 * @param bool    $force If this is true, then the chart data will be force refreshed. If false, data will be refreshed only if the chart requests live data.
+	 * @param WP_Post|null $chart The chart object.
+	 * @param int          $chart_id The chart id.
+	 * @param bool         $force If this is true, then the chart data will be force refreshed. If false, data will be refreshed only if the chart requests live data.
 	 *
 	 * @access public
 	 */
@@ -396,10 +397,11 @@ class Visualizer_Module_Setup extends Visualizer_Module {
 	 * @access public
 	 */
 	public function refreshDbChart() {
-		$schedules = get_option( Visualizer_Plugin::CF_DB_SCHEDULE, array() );
-		if ( ! $schedules ) {
+		$chart_schedules = get_option( Visualizer_Plugin::CF_DB_SCHEDULE, array() );
+		if ( ! $chart_schedules ) {
 			return;
 		}
+
 		if ( ! defined( 'VISUALIZER_DO_NOT_DIE' ) ) {
 			// define this so that the ajax call does not die
 			// this means that if the new version of pro and the old version of free are installed, only the first chart will be updated
@@ -407,22 +409,31 @@ class Visualizer_Module_Setup extends Visualizer_Module {
 		}
 
 		$new_schedules = array();
-		$now           = time();
-		foreach ( $schedules as $chart_id => $time ) {
-			$new_schedules[ $chart_id ] = $time;
-			if ( $time > $now ) {
+		$current_time  = time();
+		foreach ( $chart_schedules as $chart_id => $scheduled_time ) {
+
+			// Skip deleted charts.
+			if ( false === get_post_status( $chart_id ) ) {
 				continue;
 			}
 
-			// if the time is nigh, we force an update.
+			$new_schedules[ $chart_id ] = $scheduled_time;
+
+			// Should we do an update?
+			if ( $scheduled_time > $current_time ) {
+				continue;
+			}
+
 			$this->refresh_db_for_chart( null, $chart_id, true );
+
 			// Clear existing chart cache.
 			$cache_key = Visualizer_Plugin::CF_CHART_CACHE . '_' . $chart_id;
 			if ( get_transient( $cache_key ) ) {
 				delete_transient( $cache_key );
 			}
-			$hours                      = get_post_meta( $chart_id, Visualizer_Plugin::CF_DB_SCHEDULE, true );
-			$new_schedules[ $chart_id ] = time() + $hours * HOUR_IN_SECONDS;
+
+			$scheduled_hours            = get_post_meta( $chart_id, Visualizer_Plugin::CF_DB_SCHEDULE, true );
+			$new_schedules[ $chart_id ] = $current_time + $scheduled_hours * HOUR_IN_SECONDS;
 		}
 		update_option( Visualizer_Plugin::CF_DB_SCHEDULE, $new_schedules );
 	}
@@ -443,4 +454,18 @@ class Visualizer_Module_Setup extends Visualizer_Module {
 		}
 	}
 
+	/**
+	 * Add custom cron schedules.
+	 *
+	 * @param array $schedules The current schedules options.
+	 * @return array The modified schedules options.
+	 */
+	public function custom_cron_schedules( $schedules ) {
+		$schedules['visualizer_ten_minutes'] = array(
+			'interval' => 600,
+			'display'  => __( 'Every 10 minutes', 'visualizer' ),
+		);
+
+		return $schedules;
+	}
 }

--- a/tests/test-import.php
+++ b/tests/test-import.php
@@ -232,38 +232,8 @@ class Test_Import extends WP_Ajax_UnitTestCase {
 	 * @return void
 	 */
 	public function test_custom_cron_schedule() {
-		// Check custom schedule.
 		$schedules = wp_get_schedules();
 		$this->assertArrayHasKey( 'visualizer_ten_minutes', $schedules );
-	}
-
-	/**
-	 * Testing if the cron job is scheduled for charts data refresh.
-	 *
-	 * @return void
-	 */
-	public function test_chart_refresh_cron() {
-		$cron_jobs     = _get_cron_array();
-		$has_schedule  = false;
-		$schedule_data = array();
-
-		print_r( $cron_jobs);
-
-		foreach ( $cron_jobs as $time => $jobs ) {
-			foreach ( $jobs as $job => $data ) {
-				if ( 'visualizer_schedule_refresh_db' === $job ) {
-					$has_schedule  = true;
-					foreach ( $data as $key => $value ) {
-						$schedule_data = $value;
-						break;
-					}
-					break;
-				}
-			}
-		}
-
-		$this->assertTrue( $has_schedule );
-		$this->assertEquals( 'visualizer_ten_minutes', $schedule_data['schedule'] );
 	}
 
 	/**

--- a/tests/test-import.php
+++ b/tests/test-import.php
@@ -227,19 +227,28 @@ class Test_Import extends WP_Ajax_UnitTestCase {
 	}
 
 	/**
-	 * Testing the cron job for refreshing the charts.
+	 * Testing cron custom schedule.
+	 *
+	 * @return void
+	 */
+	public function test_custom_cron_schedule() {
+		// Check custom schedule.
+		$schedules = wp_get_schedules();
+		$this->assertArrayHasKey( 'visualizer_ten_minutes', $schedules );
+	}
+
+	/**
+	 * Testing if the cron job is scheduled for charts data refresh.
 	 *
 	 * @return void
 	 */
 	public function test_chart_refresh_cron() {
-		// Check custom schedule.
-		$schedules = wp_get_schedules();
-		$this->assertArrayHasKey( 'visualizer_ten_minutes', $schedules );
-
-		// Check if the cron job is scheduled for charts data refresh.
 		$cron_jobs     = _get_cron_array();
 		$has_schedule  = false;
 		$schedule_data = array();
+
+		print_r( $cron_jobs);
+
 		foreach ( $cron_jobs as $time => $jobs ) {
 			foreach ( $jobs as $job => $data ) {
 				if ( 'visualizer_schedule_refresh_db' === $job ) {

--- a/tests/test-import.php
+++ b/tests/test-import.php
@@ -227,6 +227,37 @@ class Test_Import extends WP_Ajax_UnitTestCase {
 	}
 
 	/**
+	 * Testing the cron job for refreshing the charts.
+	 *
+	 * @return void
+	 */
+	public function test_chart_refresh_cron() {
+		// Check custom schedule.
+		$schedules = wp_get_schedules();
+		$this->assertArrayHasKey( 'visualizer_ten_minutes', $schedules );
+
+		// Check if the cron job is scheduled for charts data refresh.
+		$cron_jobs     = _get_cron_array();
+		$has_schedule  = false;
+		$schedule_data = array();
+		foreach ( $cron_jobs as $time => $jobs ) {
+			foreach ( $jobs as $job => $data ) {
+				if ( 'visualizer_schedule_refresh_db' === $job ) {
+					$has_schedule  = true;
+					foreach ( $data as $key => $value ) {
+						$schedule_data = $value;
+						break;
+					}
+					break;
+				}
+			}
+		}
+
+		$this->assertTrue( $has_schedule );
+		$this->assertEquals( 'visualizer_ten_minutes', $schedule_data['schedule'] );
+	}
+
+	/**
 	 * Provide the fileURL for uploading the file
 	 *
 	 * @access public


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

- Use 10 minutes cron instead of hourly
- Small refactor on the schedules update

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

![image](https://github.com/Codeinwp/visualizer/assets/17597852/2035a2af-4018-4733-8363-0bdae0f46665)

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Check the Cron and see if its 10 minutes

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/visualizer-pro/issues/474
<!-- Should look like this: `Closes #1, #2, #3.` . -->
