### PR TITLE
fix: change geo region doc link

### DIFF
--- a/classes/Visualizer/Gutenberg/src/Components/Sidebar/MapSettings.js
+++ b/classes/Visualizer/Gutenberg/src/Components/Sidebar/MapSettings.js
@@ -63,7 +63,7 @@ class MapSettings extends Component {
 						<li>
 							{ __( 'A continent or a sub-continent, specified by its 3-digit code, e.g., \'011\' for Western Africa. ' ) }
 							<ExternalLink
-								href="https://google-developers.appspot.com/chart/interactive/docs/gallery/geochart#Continent_Hierarchy"
+								href="https://developers.google.com/chart/interactive/docs/gallery/geochart#continent-hierarchy-and-codes"
 							>
 								{ __( 'More info here.' ) }
 							</ExternalLink>

--- a/classes/Visualizer/Render/Sidebar/Type/GoogleCharts/Geo.php
+++ b/classes/Visualizer/Render/Sidebar/Type/GoogleCharts/Geo.php
@@ -122,7 +122,7 @@ class Visualizer_Render_Sidebar_Type_GoogleCharts_Geo extends Visualizer_Render_
 					esc_html__( 'Configure the region area to display on the map. (Surrounding areas will be displayed as well.) Can be one of the following:', 'visualizer' ) .
 					'<ul>' .
 						'<li>' . esc_html__( "'world' - A map of the entire world.", 'visualizer' ) . '</li>' .
-						'<li>' . sprintf( esc_html__( "A continent or a sub-continent, specified by its %s code, e.g., '011' for Western Africa.", 'visualizer' ), '<a href="https://google-developers.appspot.com/chart/interactive/docs/gallery/geochart#Continent_Hierarchy" target="_blank">3-digit</a>' ) . '</li>' .
+						'<li>' . sprintf( esc_html__( "A continent or a sub-continent, specified by its %s code, e.g., '011' for Western Africa.", 'visualizer' ), '<a href="https://developers.google.com/chart/interactive/docs/gallery/geochart#continent-hierarchy-and-codes" target="_blank">3-digit</a>' ) . '</li>' .
 						'<li>' . sprintf( esc_html__( "A country, specified by its %s code, e.g., 'AU' for Australia.", 'visualizer' ), '<a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2" target="_blank">ISO 3166-1 alpha-2</a>' ) . '</li>' .
 						'<li>' . sprintf( esc_html__( "A state in the United States, specified by its %s code, e.g., 'US-AL' for Alabama. Note that the resolution option must be set to either 'provinces' or 'metros'.", 'visualizer' ), '<a href="http://en.wikipedia.org/wiki/ISO_3166-2:US" target="_blank">ISO 3166-2:US</a>' ) . '</li>' .
 					'</ul>'


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Change the dead link.

> [!NOTE]
> I also updated the one from the block even if we no longer use it.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

![image](https://github.com/Codeinwp/visualizer/assets/17597852/d76d6396-83b6-4dd5-b697-8318375727a0)


### Test instructions
<!-- Describe how this pull request can be tested. -->

- Create a Geo Chart
- Check the link on `3-digit` from `Settings > Map Settings > Region`

## Check before Pull Request is ready:

* [ ] ~I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR~
* [X] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [X] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [X] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [X] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/visualizer-pro/issues/478
<!-- Should look like this: `Closes #1, #2, #3.` . -->
