### PR TITLE
Fixed PHP outdated version error

### DIFF
--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup PHP version
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.1'
+          php-version: '7.2'
           extensions: simplexml
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -49,7 +49,7 @@ jobs:
       - name: Setup PHP version
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.1'
+          php-version: '7.2'
           extensions: simplexml, mysql
           tools: phpunit-polyfills
       - name: Checkout source code

--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup PHP version
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.2'
+          php-version: '7.4'
           extensions: simplexml
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -49,7 +49,7 @@ jobs:
       - name: Setup PHP version
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.2'
+          php-version: '7.4'
           extensions: simplexml, mysql
           tools: phpunit-polyfills
       - name: Checkout source code

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -7,6 +7,7 @@
     <exclude-pattern>node_modules/*</exclude-pattern>
     <exclude-pattern>vendor/*</exclude-pattern>
     <exclude-pattern>lib/*</exclude-pattern>
+    <exclude-pattern>tests/*</exclude-pattern>
     <rule ref="WordPress-Core">
         <exclude name="Squiz.Commenting.FileComment.SpacingAfterComment" />
         <exclude name="Generic.Files.LowercasedFilename" />

--- a/tests/test-ajax.php
+++ b/tests/test-ajax.php
@@ -37,7 +37,7 @@ class Test_Visualizer_Ajax extends WP_Ajax_UnitTestCase {
 	/**
 	 * Set up.
 	 */
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 		$this->admin_user_id = $this->factory->user->create(
 			array(


### PR DESCRIPTION
### Summary
I've fixed the PHP outdated error in the PHPUnit GitHub workflow

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Issue https://github.com/Codeinwp/visualizer/pull/1171