### PR TITLE
Fixed chart rendering on page load

### DIFF
--- a/classes/Visualizer/Module/Frontend.php
+++ b/classes/Visualizer/Module/Frontend.php
@@ -699,6 +699,7 @@ class Visualizer_Module_Frontend extends Visualizer_Module {
 			?>
 		<script type="text/javascript">
 			var visualizerUserInteractionEvents = [
+				"scroll",
 				"mouseover",
 				"keydown",
 				"touchmove",

--- a/tests/e2e/specs/gutenberg-editor.spec.js
+++ b/tests/e2e/specs/gutenberg-editor.spec.js
@@ -138,7 +138,7 @@ test.describe( 'Charts with Gutenberg Editor', () => {
         await admin.visitAdminPage( 'widgets.php' );
 
         await page.getByLabel('Close', { exact: true }).click();
-        await page.getByLabel('Toggle block inserter').click();
+        await page.getByLabel('Block Inserter').click();
         await page.getByPlaceholder('Search').fill('visuali');
         await page.getByRole('option', { name: ' Visualizer Chart' }).click();
         await page.locator('div').filter({ hasText: /^Display an existing chart$/ }).click();


### PR DESCRIPTION
### Summary
Fixed charts rendering issue on page load.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/visualizer-pro/issues/493
