### PR TITLE
Fixed lazy loading when disabled

### DIFF
--- a/classes/Visualizer/Module/Frontend.php
+++ b/classes/Visualizer/Module/Frontend.php
@@ -47,7 +47,7 @@ class Visualizer_Module_Frontend extends Visualizer_Module {
 	 * @access private
 	 * @var bool
 	 */
-	private $lazy_render_script = false;
+	private $lazy_render_script = true;
 
 	/**
 	 * Constructor.
@@ -383,8 +383,9 @@ class Visualizer_Module_Frontend extends Visualizer_Module {
 		$lazy_load = isset( $settings['lazy_load_chart'] ) ? $settings['lazy_load_chart'] : false;
 		$lazy_load = apply_filters( 'visualizer_lazy_load_chart', $lazy_load, $chart->ID );
 		$container_class = 'visualizer-front-container';
-		if ( $lazy_load ) {
-			$this->lazy_render_script = true;
+		if ( ! $lazy_load ) {
+			$this->lazy_render_script = false;
+		} else {
 			$container_class .= ' visualizer-lazy-render';
 		}
 

--- a/js/render-facade.js
+++ b/js/render-facade.js
@@ -128,16 +128,30 @@ var vizClipboard1=null;
     }
 
     function displayChartsOnFrontEnd() {
+        $(window).on('scroll', function() {
+            $('div.visualizer-front:not(.viz-facade-loaded):not(.visualizer-lazy):not(.visualizer-cw-error):empty').each(function(index, element){
+                // Do not render charts that are intentionally hidden.
+                var style = window.getComputedStyle(element);
+                if (style.display === 'none' || style.visibility === 'hidden') {
+                    return;
+                }
 
-        $('div.visualizer-front:not(.viz-facade-loaded):not(.visualizer-lazy):not(.visualizer-cw-error):empty').each(function(index, element){
+                var id = $(element).addClass('viz-facade-loaded').attr('id');
+                setTimeout(function(){
+                    // Add a short delay between each chart to avoid overloading the browser event loop.
+                    showChart(id);
+                }, ( index + 1 ) * 100);
+            });
+        });
 
+        $('div.visualizer-front-container:not(.visualizer-lazy-render)').each(function(index, element){
             // Do not render charts that are intentionally hidden.
-            var style = window.getComputedStyle(element);
+            var style = window.getComputedStyle($(element).find('.visualizer-front')[0]);
             if (style.display === 'none' || style.visibility === 'hidden') {
                 return;
             }
-           
-            var id = $(element).addClass('viz-facade-loaded').attr('id');
+
+            var id = $(element).find('.visualizer-front').addClass('viz-facade-loaded').attr('id');
             setTimeout(function(){
                 // Add a short delay between each chart to avoid overloading the browser event loop.
                 showChart(id);

--- a/js/render-facade.js
+++ b/js/render-facade.js
@@ -131,12 +131,12 @@ var vizClipboard1=null;
         $(window).on('scroll', function() {
             $('div.visualizer-front:not(.viz-facade-loaded):not(.visualizer-lazy):not(.visualizer-cw-error):empty').each(function(index, element){
                 // Do not render charts that are intentionally hidden.
-                var style = window.getComputedStyle(element);
+                const style = window.getComputedStyle(element);
                 if (style.display === 'none' || style.visibility === 'hidden') {
                     return;
                 }
 
-                var id = $(element).addClass('viz-facade-loaded').attr('id');
+                const id = $(element).addClass('viz-facade-loaded').attr('id');
                 setTimeout(function(){
                     // Add a short delay between each chart to avoid overloading the browser event loop.
                     showChart(id);
@@ -146,12 +146,12 @@ var vizClipboard1=null;
 
         $('div.visualizer-front-container:not(.visualizer-lazy-render)').each(function(index, element){
             // Do not render charts that are intentionally hidden.
-            var style = window.getComputedStyle($(element).find('.visualizer-front')[0]);
+            const style = window.getComputedStyle($(element).find('.visualizer-front')[0]);
             if (style.display === 'none' || style.visibility === 'hidden') {
                 return;
             }
 
-            var id = $(element).find('.visualizer-front').addClass('viz-facade-loaded').attr('id');
+            const id = $(element).find('.visualizer-front').addClass('viz-facade-loaded').attr('id');
             setTimeout(function(){
                 // Add a short delay between each chart to avoid overloading the browser event loop.
                 showChart(id);


### PR DESCRIPTION
### Summary
Fixed the lazy loading when chart is diable for lazy-load

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/visualizer-pro/issues/493#issuecomment-2900266586
