### PR TITLE
fix: number format not being applied properly

### DIFF
--- a/js/render-google.js
+++ b/js/render-google.js
@@ -352,19 +352,14 @@ var isResizeRequest = false;
                     }
                     break;
                 default:
-                    for (i = 0; i < settings.series.length; i++) {
-                        if (!series[i + 1] || typeof settings.series[i] === 'undefined') {
-                            continue;
-                        }
-                        var seriesIndexToUse = i + 1;
-
-                        // if an annotation "swallowed" a series, use the following one.
-                        if(series_annotations.includes(i)){
-                            seriesIndexToUse++;
-                        }
-                        if ( series[seriesIndexToUse] ) {
-                            format_data(id, table, series[seriesIndexToUse].type, settings.series[i].format, seriesIndexToUse);
-                        }
+                    // Single-pass: walk columns, skip annotation/helper roles, apply formats in order.
+                    var k = 0; // index into settings.series (visible series)
+                    for (var c = 1; c < series.length && k < settings.series.length; c++) { // skip label at 0
+                        if (table.getColumnProperty(c, 'role')) continue; // helper/annotation column
+                        var s = settings.series[k++];
+                        if (!s || !s.format) continue;
+                        if (!series[c]) continue;
+                        format_data(id, table, series[c].type, s.format, c);
                     }
                     break;
             }


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Fixes an issue investigated during support day that doesn't apply formatting to all the items of the charts.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES/NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Follow the steps laid here on the HS ticket: https://secure.helpscout.net/conversation/3035307261/470340?viewId=212385
- Make sure the format is applied correctly to all the items.
- Also try with different charts to confirm.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/visualizer/issues/1221.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
