### PR TITLE
refactor: change Black Friday labels

### DIFF
--- a/classes/Visualizer/Module/Admin.php
+++ b/classes/Visualizer/Module/Admin.php
@@ -1479,13 +1479,21 @@ class Visualizer_Module_Admin extends Visualizer_Module {
 		$is_expired = 'expired' === $status || 'active-expired' === $status;
 
 		if ( $is_pro ) {
+			// translators: %s is the discount percentage.
+			$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - up to %s off', 'visualizer' ), '30%' );
 			// translators: %1$s - discount, %2$s - discount.
 			$message = sprintf( __( 'Upgrade your Visualizer Pro plan: %1$s off this week. Already on the plan you need? Renew early and save up to %2$s.', 'visualizer' ), '30%', '20%' );
 			$cta_label = __( 'See your options', 'visualizer' );
 		} elseif ( $is_expired ) {
+			// translators: %s is the discount percentage.
+			$config['upgrade_menu_text'] = sprintf( __( 'BF Sale - %s off', 'visualizer' ), '50%' );
+			// translators: %s is the discount percentage.
+			$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - %s off', 'visualizer' ), '50%' );
 			$message = __( 'Your Visualizer Pro features are still here, just locked. Renew at a reduced rate this week.', 'visualizer' );
 			$cta_label = __( 'Reactivate now', 'visualizer' );
 		} else {
+			// translators: %s is the discount percentage.
+			$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - %s off', 'visualizer' ), '60%' );
 			$config['title'] = __( 'Visualizer Pro: 60% off this week', 'visualizer' );
 			// translators: %s is the discount percentage.
 			$config['upgrade_menu_text'] = sprintf( __( 'BF Sale - %s off', 'visualizer' ), '60%' );
@@ -1498,12 +1506,7 @@ class Visualizer_Module_Admin extends Visualizer_Module {
 		);
 
 		if ( ( $is_pro || $is_expired ) && ! empty( $pro_product_slug ) ) {
-			// translators: %s is the discount percentage.
-			$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - up to %s off', 'visualizer' ), '30%' );
 			$config['plugin_meta_targets'] = array( $pro_product_slug );
-		} else {
-			// translators: %s is the discount percentage.
-			$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - %s off', 'visualizer' ), '60%' );
 		}
 
 		$config['message']   = $message;

--- a/classes/Visualizer/Module/Admin.php
+++ b/classes/Visualizer/Module/Admin.php
@@ -1273,16 +1273,19 @@ class Visualizer_Module_Admin extends Visualizer_Module {
 		}
 
 		if ( $plugin_file === plugin_basename( VISUALIZER_BASEFILE ) ) {
+			$is_black_friday = apply_filters( 'themeisle_sdk_is_black_friday_sale', false );
 			// knowledge base link
 			$plugin_meta[] = sprintf(
 				'<a href="' . VISUALIZER_MAIN_DOC . '" target="_blank">%s</a>',
 				esc_html__( 'Docs', 'visualizer' )
 			);
-			// flattr link
-			$plugin_meta[] = sprintf(
-				'<a style="color:red" href="' . tsdk_utmify( Visualizer_Plugin::PRO_TEASER_URL, 'pluginrow' ) . '" target="_blank">%s</a>',
-				esc_html__( 'Get Visualizer Pro', 'visualizer' )
-			);
+			if ( ! $is_black_friday ) {
+				// flattr link
+				$plugin_meta[] = sprintf(
+					'<a style="color:red" href="' . tsdk_utmify( Visualizer_Plugin::PRO_TEASER_URL, 'pluginrow' ) . '" target="_blank">%s</a>',
+					esc_html__( 'Get Visualizer Pro', 'visualizer' )
+				);
+			}
 		}
 
 		return $plugin_meta;
@@ -1470,6 +1473,7 @@ class Visualizer_Module_Admin extends Visualizer_Module {
 		$plan    = apply_filters( 'product_visualizer_license_plan', 0 );
 		$license = apply_filters( 'product_visualizer_license_key', false );
 		$status  = apply_filters( 'product_visualizer_license_status', false );
+		$pro_product_slug = defined( 'VISUALIZER_PRO_BASEFILE' ) ? basename( dirname( VISUALIZER_PRO_BASEFILE ) ) : '';
 
 		$is_pro  = 'valid' === $status;
 		$is_expired = 'expired' === $status || 'active-expired' === $status;
@@ -1491,8 +1495,18 @@ class Visualizer_Module_Admin extends Visualizer_Module {
 			'expired'  => $is_expired ? '1' : false,
 		);
 
-		$config['message']  = $message;
+		if ( ( $is_pro || $is_expired ) && ! empty( $pro_product_slug ) ) {
+			// translators: %s is the discount percentage.
+			$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - up to %s off', 'visualizer' ), '30%' );
+			$config['plugin_meta_targets'] = array( $pro_product_slug );
+		} else {
+			// translators: %s is the discount percentage.
+			$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - %s off', 'visualizer' ), '60%' );
+		}
+
+		$config['message']   = $message;
 		$config['cta_label'] = $cta_label;
+
 		$config['sale_url'] = add_query_arg(
 			$url_params,
 			tsdk_translate_link( tsdk_utmify( 'https://themeisle.link/vizualizer-bf', 'bfcm', 'visualizer' ) )

--- a/classes/Visualizer/Module/Admin.php
+++ b/classes/Visualizer/Module/Admin.php
@@ -1464,29 +1464,35 @@ class Visualizer_Module_Admin extends Visualizer_Module {
 	public function add_black_friday_data( $configs ) {
 		$config = $configs['default'];
 
-		// translators: %1$s - HTML tag, %2$s - discount, %3$s - HTML tag, %4$s - product name.
-		$message_template = __( 'Our biggest sale of the year: %1$sup to %2$s OFF%3$s on %4$s. Don\'t miss this limited-time offer.', 'visualizer' );
-		$product_label    = 'Visualizer';
-		$discount         = '70%';
+		$message = __( 'Database queries, private charts, auto-sync. Go beyond basic charts. Exclusively for existing Visualizer users.', 'visualizer' );
+		$cta_label = __( 'Get Visualizer Pro', 'visualizer' );
 
 		$plan    = apply_filters( 'product_visualizer_license_plan', 0 );
 		$license = apply_filters( 'product_visualizer_license_key', false );
-		$is_pro  = 0 < $plan;
+		$status  = apply_filters( 'product_visualizer_license_status', false );
+
+		$is_pro  = 'valid' === $status;
+		$is_expired = 'expired' === $status || 'active-expired' === $status;
 
 		if ( $is_pro ) {
-			// translators: %1$s - HTML tag, %2$s - discount, %3$s - HTML tag, %4$s - product name.
-			$message_template = __( 'Get %1$sup to %2$s off%3$s when you upgrade your %4$s plan or renew early.', 'visualizer' );
-			$product_label    = 'Visualizer Pro';
-			$discount         = '30%';
+			// translators: %1$s - discount, %2$s - discount.
+			$message = sprintf( __( 'Upgrade your Visualizer Pro plan: %1$s off this week. Already on the plan you need? Renew early and save up to %2$s.', 'visualizer' ), '30%', '20%' );
+			$cta_label = __( 'See your options', 'visualizer' );
+		} elseif ( $is_expired ) {
+			$message = __( 'Your Visualizer Pro features are still here, just locked. Renew at a reduced rate this week.', 'visualizer' );
+			$cta_label = __( 'Reactivate now', 'visualizer' );
+		} else {
+			$config['title'] = __( 'Visualizer Pro: 60% off this week', 'visualizer' );
 		}
 
-		$product_label = sprintf( '<strong>%s</strong>', $product_label );
 		$url_params    = array(
 			'utm_term' => $is_pro ? 'plan-' . $plan : 'free',
 			'lkey'     => ! empty( $license ) ? $license : false,
+			'expired'  => $is_expired ? '1' : false,
 		);
 
-		$config['message']  = sprintf( $message_template, '<strong>', $discount, '</strong>', $product_label );
+		$config['message']  = $message;
+		$config['cta_label'] = $cta_label;
 		$config['sale_url'] = add_query_arg(
 			$url_params,
 			tsdk_translate_link( tsdk_utmify( 'https://themeisle.link/vizualizer-bf', 'bfcm', 'visualizer' ) )

--- a/classes/Visualizer/Module/Admin.php
+++ b/classes/Visualizer/Module/Admin.php
@@ -1487,6 +1487,8 @@ class Visualizer_Module_Admin extends Visualizer_Module {
 			$cta_label = __( 'Reactivate now', 'visualizer' );
 		} else {
 			$config['title'] = __( 'Visualizer Pro: 60% off this week', 'visualizer' );
+			// translators: %s is the discount percentage.
+			$config['upgrade_menu_text'] = sprintf( __( 'BF Sale - %s off', 'visualizer' ), '60%' );
 		}
 
 		$url_params    = array(


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

- Add the labels for Black Friday promotion. Based on https://github.com/Codeinwp/themeisle/issues/1854
- Complete the Formbricks integration

### Screenshots <!-- if applicable -->

<img width="2250" height="1440" alt="CleanShot 2026-03-18 at 16 18 00@2x" src="https://github.com/user-attachments/assets/356b3c8f-6f26-46d1-ba89-69f18dfc690d" />
<img width="2254" height="1430" alt="CleanShot 2026-03-18 at 16 18 40@2x" src="https://github.com/user-attachments/assets/bdcf81a7-8bc5-4468-8d98-2d33517d25b0" />
<img width="2560" height="1644" alt="CleanShot 2026-03-18 at 16 19 20@2x" src="https://github.com/user-attachments/assets/e725a3cd-457d-4c9b-b0ef-4ea9be151e81" />



### Test instructions
<!-- Describe how this pull request can be tested. -->

- Install this plugin: https://github.com/Soare-Robert-Daniel/test-black-friday
- Use this SDK version: https://github.com/Codeinwp/themeisle-sdk-main/pull/309
- Test:
  - If the notice appears during the Black Friday period.
  - If the labels change based on the license status (described in the spreadsheet)
  - If the notice can be dismissed.
  - If the notice appears only if the plugin is 3 days old. Warning: You will see the notice if you have another product that is older than 3 days; in this case, better to disable them.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [ ] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [ ] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [ ] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [ ] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/themeisle/issues/1854
<!-- Should look like this: `Closes #1, #2, #3.` . -->
