### PR TITLE
fix: prevent SSRF via JSON import handlers

### DIFF
--- a/classes/Visualizer/Module/Chart.php
+++ b/classes/Visualizer/Module/Chart.php
@@ -170,6 +170,10 @@ class Visualizer_Module_Chart extends Visualizer_Module {
 	public function getJsonRoots() {
 		check_ajax_referer( Visualizer_Plugin::ACTION_JSON_GET_ROOTS . Visualizer_Plugin::VERSION, 'security' );
 
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			wp_send_json_error( array( 'msg' => esc_html__( 'You do not have permission to perform this action.', 'visualizer' ) ) );
+		}
+
 		$params     = wp_parse_args( $_POST['params'] );
 
 		$source = new Visualizer_Source_Json( $params );
@@ -191,6 +195,10 @@ class Visualizer_Module_Chart extends Visualizer_Module {
 	 */
 	public function getJsonData() {
 		check_ajax_referer( Visualizer_Plugin::ACTION_JSON_GET_DATA . Visualizer_Plugin::VERSION, 'security' );
+
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			wp_send_json_error( array( 'msg' => esc_html__( 'You do not have permission to perform this action.', 'visualizer' ) ) );
+		}
 
 		$params = wp_parse_args( $_POST['params'] );
 

--- a/classes/Visualizer/Source/Json.php
+++ b/classes/Visualizer/Source/Json.php
@@ -468,7 +468,7 @@ class Visualizer_Source_Json extends Visualizer_Source {
 		}
 
 		do_action( 'themeisle_log_event', Visualizer_Plugin::NAME, sprintf( 'Connecting to %s with args = %s ', $url, print_r( $args, true ) ), 'debug', __FILE__, __LINE__ );
-		return wp_remote_request( $url, $args );
+		return wp_safe_remote_request( $url, $args );
 	}
 
 	/**

--- a/tests/test-ajax.php
+++ b/tests/test-ajax.php
@@ -331,6 +331,112 @@ class Test_Visualizer_Ajax extends WP_Ajax_UnitTestCase {
 	}
 
 	/**
+	 * JSON get-roots must be denied for users without `edit_posts` (issue #591 access-control fix).
+	 */
+	public function test_json_get_roots_denied_for_subscriber() {
+		wp_set_current_user( $this->subscriber_user_id );
+		$this->_setRole( 'subscriber' );
+
+		$_GET['security'] = wp_create_nonce( Visualizer_Plugin::ACTION_JSON_GET_ROOTS . Visualizer_Plugin::VERSION );
+		$_POST['params']  = array(
+			'url'    => 'http://127.0.0.1:9999/latest/meta-data/',
+			'method' => 'GET',
+		);
+
+		try {
+			$this->_handleAjax( Visualizer_Plugin::ACTION_JSON_GET_ROOTS );
+		} catch ( WPAjaxDieContinueException $e ) {
+			// We expected this, do nothing.
+		}
+
+		$response = json_decode( $this->_last_response );
+		$this->assertIsObject( $response );
+		$this->assertFalse( $response->success );
+		$this->assertEquals( 'You do not have permission to perform this action.', $response->data->msg );
+	}
+
+	/**
+	 * JSON get-data must be denied for users without `edit_posts` (issue #591 access-control fix).
+	 */
+	public function test_json_get_data_denied_for_subscriber() {
+		wp_set_current_user( $this->subscriber_user_id );
+		$this->_setRole( 'subscriber' );
+
+		$_GET['security'] = wp_create_nonce( Visualizer_Plugin::ACTION_JSON_GET_DATA . Visualizer_Plugin::VERSION );
+		$_POST['params']  = array(
+			'url'    => 'http://127.0.0.1:9999/',
+			'method' => 'GET',
+			'chart'  => 1,
+		);
+
+		try {
+			$this->_handleAjax( Visualizer_Plugin::ACTION_JSON_GET_DATA );
+		} catch ( WPAjaxDieContinueException $e ) {
+			// We expected this, do nothing.
+		}
+
+		$response = json_decode( $this->_last_response );
+		$this->assertIsObject( $response );
+		$this->assertFalse( $response->success );
+		$this->assertEquals( 'You do not have permission to perform this action.', $response->data->msg );
+	}
+
+	/**
+	 * A permitted user (contributor) is not blocked by the guard, and the JSON source fetches through the
+	 * SSRF-safe transport (`reject_unsafe_urls`), matching the CSV path (issue #591 SSRF fix).
+	 */
+	public function test_json_get_roots_allowed_for_contributor_uses_safe_transport() {
+		wp_set_current_user( $this->contibutor_user_id );
+		$this->_setRole( 'contributor' );
+
+		$captured = array();
+		add_filter(
+			'pre_http_request',
+			function ( $pre, $args, $url ) use ( &$captured ) {
+				$captured[] = array(
+					'url'    => $url,
+					'reject' => ! empty( $args['reject_unsafe_urls'] ),
+				);
+				return array(
+					'headers'  => array(),
+					'body'     => wp_json_encode( array( 'results' => array( array( 'id' => 1 ) ) ) ),
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+					'cookies'  => array(),
+					'filename' => null,
+				);
+			},
+			10,
+			3
+		);
+
+		$_GET['security'] = wp_create_nonce( Visualizer_Plugin::ACTION_JSON_GET_ROOTS . Visualizer_Plugin::VERSION );
+		$_POST['params']  = array(
+			'url'    => 'http://127.0.0.1:9999/latest/meta-data/',
+			'method' => 'GET',
+		);
+
+		try {
+			$this->_handleAjax( Visualizer_Plugin::ACTION_JSON_GET_ROOTS );
+		} catch ( WPAjaxDieContinueException $e ) {
+			// We expected this, do nothing.
+		}
+
+		$response = json_decode( $this->_last_response );
+		$this->assertIsObject( $response );
+		// The capability guard must NOT block a user who has edit_posts.
+		$msg = isset( $response->data->msg ) ? $response->data->msg : '';
+		$this->assertNotEquals( 'You do not have permission to perform this action.', $msg );
+		// Every outbound request for the JSON source must use the SSRF-safe transport.
+		$this->assertNotEmpty( $captured, 'The JSON source did not attempt any fetch.' );
+		foreach ( $captured as $req ) {
+			$this->assertTrue( $req['reject'], 'JSON fetch must use wp_safe_remote_* (reject_unsafe_urls => true).' );
+		}
+	}
+
+	/**
 	 * Utility method to mock pro version.
 	 */
 	private function enable_pro() {


### PR DESCRIPTION
## Summary

Fixes a server-side request forgery (SSRF) in the JSON import feature. Related issue: https://github.com/Codeinwp/visualizer-pro/issues/591

The `getJsonRoots()` and `getJsonData()` AJAX handlers verified **only a nonce** before fetching a user-supplied URL server-side, and the fetch used the unsafe `wp_remote_request()`. Because the chart editor is gated by `edit_posts` and localizes the JSON nonces, a **Contributor**-level user could read the nonce and make WordPress fetch arbitrary internal URLs (`127.0.0.1`, private ranges, etc.), with the response reflected back in `roots` / `table` — a non-blind SSRF.

The CSV/remote path already does this correctly (`wp_safe_remote_get()` + `wp_http_validate_url()`); only the JSON source was left on the raw transport.

## Changes

- **`classes/Visualizer/Module/Chart.php`** — add a `current_user_can( 'edit_posts' )` guard to `getJsonRoots()` and `getJsonData()`, matching the sibling AJAX handlers in the file.
- **`classes/Visualizer/Source/Json.php`** — switch `connect()` from `wp_remote_request()` to `wp_safe_remote_request()`, matching the SSRF-safe transport used by the CSV path.
- **`tests/test-ajax.php`** — three regression tests: access-control guard on both handlers, and confirmation the JSON source fetches through the safe transport (`reject_unsafe_urls`).

## Testing

- New tests pass with the fix (`OK (3 tests, 10 assertions)`) and fail on the unpatched code (verified by reverting), so they genuinely detect the vulnerability.
- `phpcs` passes clean on all changed files.
