### PR TITLE
Fix lazy-rendered charts staying blank on script load-order race

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -5,6 +5,9 @@
     "."
   ],
   "themes": [],
+  "mappings": {
+    "wp-content/mu-plugins/visualizer-e2e-force-lazy-render.php": "./tests/e2e/config/force-lazy-render.php"
+  },
   "config": {
     "WP_DEBUG": true,
     "WP_DEBUG_LOG": true,

--- a/classes/Visualizer/Module/Frontend.php
+++ b/classes/Visualizer/Module/Frontend.php
@@ -803,14 +803,20 @@ class Visualizer_Module_Frontend extends Visualizer_Module {
 
 			function visualizerLoadScripts() {
 				document.querySelectorAll("script[data-visualizer-script]").forEach(function(elem) {
-					jQuery.getScript( elem.getAttribute("data-visualizer-script") )
-					.done( function( script, textStatus ) {
-						elem.setAttribute("src", elem.getAttribute("data-visualizer-script"));
-						elem.removeAttribute("data-visualizer-script");
+					// Replace the placeholder with a real script tag using async=false:
+					// scripts download in parallel but execute in insertion order, which
+					// preserves the WordPress dependency order. Parallel jQuery.getScript
+					// calls could execute render-facade.js before the chart renderer had
+					// registered its render event listener, leaving charts blank.
+					var script = document.createElement("script");
+					script.src = elem.getAttribute("data-visualizer-script");
+					script.async = false;
+					script.onload = function() {
 						setTimeout( function() {
 							visualizerRefreshChart();
 						} );
-					} );
+					};
+					elem.parentNode.replaceChild(script, elem);
 				});
 			}
 

--- a/tests/e2e/config/force-lazy-render.php
+++ b/tests/e2e/config/force-lazy-render.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * E2E test helper (loaded as an mu-plugin via .wp-env.json).
+ *
+ * Charts created through the quick wizard have no `lazy_load_chart` setting,
+ * so force lazy rendering on the frontend to exercise the delayed script
+ * loader in lazy-render.spec.js. Elementor previews are unaffected: the
+ * widget force-disables lazy rendering with the same filter during render.
+ */
+add_filter( 'visualizer_lazy_load_chart', '__return_true' );

--- a/tests/e2e/specs/lazy-render.spec.js
+++ b/tests/e2e/specs/lazy-render.spec.js
@@ -24,7 +24,8 @@ test.describe( 'Lazy rendered charts (frontend)', () => {
 	} );
 
 	async function createChartOnPost( admin, page, requestUtils ) {
-		// New charts have lazy rendering enabled by default.
+		// Lazy rendering is forced on by tests/e2e/config/force-lazy-render.php
+		// (mapped as an mu-plugin in .wp-env.json).
 		const chartId = await createChartWithAdmin( admin, page );
 
 		const post = await requestUtils.createPost( {

--- a/tests/e2e/specs/lazy-render.spec.js
+++ b/tests/e2e/specs/lazy-render.spec.js
@@ -1,0 +1,75 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+/**
+ * Internal dependencies
+ */
+const { deleteAllCharts, createChartWithAdmin } = require( '../utils/common' );
+
+/**
+ * Regression tests for https://github.com/Codeinwp/visualizer/issues/1319
+ *
+ * Charts with lazy rendering enabled load their scripts only after the first
+ * user interaction, via `script[data-visualizer-script]` placeholders. The
+ * loader must preserve the WordPress dependency order: if render-facade.js
+ * executes before the chart renderer (render-google.js etc.) has registered
+ * its `visualizer:render:chart:start` listener, the render event is lost and
+ * the chart stays blank forever.
+ */
+test.describe( 'Lazy rendered charts (frontend)', () => {
+	test.beforeEach( async ( { requestUtils } ) => {
+		await deleteAllCharts( requestUtils );
+	} );
+
+	async function createChartOnPost( admin, page, requestUtils ) {
+		// New charts have lazy rendering enabled by default.
+		const chartId = await createChartWithAdmin( admin, page );
+
+		const post = await requestUtils.createPost( {
+			title: 'Lazy render',
+			content: `[visualizer id="${ chartId }" lazy="no" class=""]`,
+			status: 'publish',
+		} );
+
+		return { chartId, post };
+	}
+
+	async function triggerLazyLoader( page ) {
+		// Scripts are swapped to `data-visualizer-script` placeholders.
+		await expect( page.locator( 'script[data-visualizer-script]' ).first() ).toBeAttached();
+
+		// The loader starts on the first user interaction.
+		await page.evaluate( () => window.dispatchEvent( new Event( 'scroll' ) ) );
+	}
+
+	test( 'chart renders when the renderer script loads after render-facade.js', async ( { admin, page, requestUtils } ) => {
+		const { chartId, post } = await createChartOnPost( admin, page, requestUtils );
+
+		// Delay the chart renderer scripts so render-facade.js would win the
+		// load race — the deterministic reproduction of issue #1319.
+		await page.route( /js\/render-(google|chartjs|datatables)\.js/, async ( route ) => {
+			await new Promise( ( resolve ) => setTimeout( resolve, 2000 ) );
+			await route.continue();
+		} );
+
+		await page.goto( `/?p=${ post.id }` );
+		await triggerLazyLoader( page );
+
+		const chart = page.locator( `.visualizer-front-${ chartId }` ).first();
+		await expect( chart ).toHaveClass( /visualizer-chart-loaded/, { timeout: 15000 } );
+		await expect( chart.locator( 'svg, canvas, table' ).first() ).toBeVisible();
+	} );
+
+	test( 'chart renders without artificial script delay', async ( { admin, page, requestUtils } ) => {
+		const { chartId, post } = await createChartOnPost( admin, page, requestUtils );
+
+		await page.goto( `/?p=${ post.id }` );
+		await triggerLazyLoader( page );
+
+		const chart = page.locator( `.visualizer-front-${ chartId }` ).first();
+		await expect( chart ).toHaveClass( /visualizer-chart-loaded/, { timeout: 15000 } );
+		await expect( chart.locator( 'svg, canvas, table' ).first() ).toBeVisible();
+	} );
+} );


### PR DESCRIPTION
Closes #1319

## Root cause
`visualizerLoadScripts()` fetched all `script[data-visualizer-script]` placeholders with parallel `jQuery.getScript()` calls, discarding the WordPress dependency order. When `render-facade.js` executed before the chart renderer (`render-google.js` etc.), the facade fired its one-shot `visualizer:render:chart:start` event with no listener registered. `all_charts` was never set, so every later resize-based recovery iterated an empty object — the chart stayed blank until a full page reload.

## Fix
Replace each placeholder with a real `<script>` element using `async = false`: browsers download the scripts in parallel but execute them in insertion order, which is the order WordPress printed them (renderer before facade). Side benefits: no more `_=timestamp` cache-busting on every page view, and one failed script no longer affects the others.

## Reproduction / verification
Deterministic repro: delay `render-google.js` by a few seconds (slow CDN / cache-miss simulation), load a page with a lazy-render chart, interact. Before: blank forever. After: renders once scripts arrive. Verified with free 4.0.4 alone and with Visualizer Pro 2.0.1 active.

## Tests
New `tests/e2e/specs/lazy-render.spec.js`:
- race regression: renderer scripts delayed 2s via `page.route` — fails on the old loader, passes with the fix
- sanity: same flow without delay

🤖 Generated with [Claude Code](https://claude.com/claude-code)