### PR TITLE
fix: scheduled CSV refresh runs without a logged-in user

### DIFF
--- a/classes/Visualizer/Module/Chart.php
+++ b/classes/Visualizer/Module/Chart.php
@@ -1222,12 +1222,13 @@ class Visualizer_Module_Chart extends Visualizer_Module {
 		// if this is being called internally from pro and VISUALIZER_DO_NOT_DIE is set.
 		// otherwise, assume this is a normal web request.
 		$can_die    = ! ( defined( 'VISUALIZER_DO_NOT_DIE' ) && VISUALIZER_DO_NOT_DIE );
+		// $can_die also gates the capability checks below, so VISUALIZER_DO_NOT_DIE must stay internal-only (never set from request input or globally).
 
-		// validate nonce
+		// validate nonce; capability check applies to web requests only, not trusted internal calls.
 		if (
 			! isset( $_GET['nonce'] ) ||
 			! wp_verify_nonce( $_GET['nonce'], 'visualizer-upload-data' ) ||
-			! current_user_can( 'edit_posts' )
+			( $can_die && ! current_user_can( 'edit_posts' ) )
 		) {
 			if ( ! $can_die ) {
 				return;
@@ -1244,7 +1245,7 @@ class Visualizer_Module_Chart extends Visualizer_Module {
 			! $chart_id ||
 			! $chart ||
 			$chart->post_type !== Visualizer_Plugin::CPT_VISUALIZER ||
-			! current_user_can( 'edit_post', $chart_id )
+			( $can_die && ! current_user_can( 'edit_post', $chart_id ) )
 		) {
 			if ( ! $can_die ) {
 				return;

--- a/tests/test-schedule.php
+++ b/tests/test-schedule.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Tests for background/scheduled import behavior.
+ *
+ * @package     visualizer
+ * @subpackage  Tests
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * Scheduled/background refresh must still import with no logged-in user (regression for visualizer-pro#590).
+ *
+ * ponytail: defines VISUALIZER_DO_NOT_DIE process-wide; isolate this test if one ever needs the exit/die path.
+ */
+class Test_Visualizer_Schedule extends WP_UnitTestCase {
+
+	/**
+	 * Internal upload (no user, VISUALIZER_DO_NOT_DIE set) must still import and persist chart data.
+	 */
+	public function test_internal_upload_imports_without_logged_in_user() {
+		wp_set_current_user( 0 );
+		$this->assertFalse( current_user_can( 'edit_posts' ), 'precondition: background context has no editing user' );
+
+		$chart_id = self::factory()->post->create(
+			array(
+				'post_type'    => Visualizer_Plugin::CPT_VISUALIZER,
+				'post_status'  => 'publish',
+				'post_content' => 'OLD-CONTENT',
+			)
+		);
+
+		// mimic Pro's internal invocation; clean superglobals so prior tests don't reroute uploadData().
+		$_GET = $_POST = $_FILES = array();
+		define( 'VISUALIZER_DO_NOT_DIE', true );
+		$_GET['nonce']        = wp_create_nonce( 'visualizer-upload-data' );
+		$_GET['chart']        = $chart_id;
+		$_POST['editor-type'] = 'text';
+		$_POST['chart_data']  = "Name,Value\nstring,number\nAlpha,111\nBeta,222";
+
+		do_action( 'wp_ajax_' . Visualizer_Plugin::ACTION_UPLOAD_DATA );
+
+		$content = get_post_field( 'post_content', $chart_id );
+		$this->assertStringContainsString( 'Alpha', $content, 'scheduled/background import must update chart data without a logged-in user' );
+	}
+}


### PR DESCRIPTION
Fixes the scheduled remote-CSV auto-sync silently stopping. Related issue: https://github.com/Codeinwp/visualizer-pro/issues/590

## Problem
Background schedule/refresh calls `uploadData()` with no logged-in user and `VISUALIZER_DO_NOT_DIE` set. Since Feb 2026 that handler also requires `edit_posts`/`edit_post`, so with no user the check fails and the internal call `return`s silently — the chart never refreshes while Pro advances the next-run time anyway.

## Fix
Gate the two capability checks on `$can_die` so they apply to real web requests only. Trusted internal calls (the sole context that defines `VISUALIZER_DO_NOT_DIE`, never from request input) proceed and import.

## Safety
- Web path unchanged: when `$can_die` is true the expressions are identical to before, so all existing checks (incl. the nonce) stay enforced.
- `VISUALIZER_DO_NOT_DIE` is defined only in internal scheduled handlers, never from request data, so the relaxation can't be reached by an attacker.

## Tests
`tests/test-schedule.php` — asserts a no-user internal import updates the chart; green with the fix, red without. Full suite passes (the only errors are a pre-existing `tsdk_utmify()` gap in `Test_Revisions`, unrelated).

