### PR TITLE
fix: centralize safe remote imports for SSRF

### DIFF
--- a/classes/Visualizer/Module/AIBuilder.php
+++ b/classes/Visualizer/Module/AIBuilder.php
@@ -221,11 +221,12 @@ class Visualizer_Module_AIBuilder extends Visualizer_Module {
 		$response = Visualizer_Remote_Fetch::request(
 			$url,
 			array(
-				'timeout'     => 15,
-				'redirection' => 5,
-				'stream'      => true,
-				'filename'    => $tmpfile,
-				'headers'     => array( 'Range' => 'bytes=0-3' ),
+				'timeout'             => 15,
+				'redirection'         => 5,
+				'stream'              => true,
+				'filename'            => $tmpfile,
+				'headers'             => array( 'Range' => 'bytes=0-3' ),
+				'limit_response_size' => 4,
 			)
 		);
 

--- a/classes/Visualizer/Module/AIBuilder.php
+++ b/classes/Visualizer/Module/AIBuilder.php
@@ -206,7 +206,7 @@ class Visualizer_Module_AIBuilder extends Visualizer_Module {
 	/**
 	 * Determines whether a remote URL serves an XLSX file.
 	 *
-	 * Uses wp_safe_remote_get() and checks ZIP magic number (PK\x03\x04).
+	 * Uses the shared remote-fetch policy and checks ZIP magic number (PK\x03\x04).
 	 *
 	 * @access private
 	 * @param string $url The remote URL to probe.
@@ -218,7 +218,7 @@ class Visualizer_Module_AIBuilder extends Visualizer_Module {
 			return false;
 		}
 
-		$response = wp_safe_remote_get(
+		$response = Visualizer_Remote_Fetch::request(
 			$url,
 			array(
 				'timeout'     => 15,

--- a/classes/Visualizer/Module/Chart.php
+++ b/classes/Visualizer/Module/Chart.php
@@ -1060,11 +1060,12 @@ class Visualizer_Module_Chart extends Visualizer_Module {
 		$response = Visualizer_Remote_Fetch::request(
 			$url,
 			array(
-				'timeout'    => 10,
-				'user-agent' => 'WordPress/' . get_bloginfo( 'version' ),
-				'headers'    => array( 'Range' => 'bytes=0-3' ),
-				'stream'     => true,
-				'filename'   => $tmpfile,
+				'timeout'             => 10,
+				'user-agent'          => 'WordPress/' . get_bloginfo( 'version' ),
+				'headers'             => array( 'Range' => 'bytes=0-3' ),
+				'stream'              => true,
+				'filename'            => $tmpfile,
+				'limit_response_size' => 4,
 			)
 		);
 

--- a/classes/Visualizer/Module/Chart.php
+++ b/classes/Visualizer/Module/Chart.php
@@ -204,7 +204,8 @@ class Visualizer_Module_Chart extends Visualizer_Module {
 
 		$chart_id = $params['chart'];
 
-		if ( empty( $chart_id ) ) {
+		$chart = $chart_id ? get_post( $chart_id ) : null;
+		if ( ! $chart || Visualizer_Plugin::CPT_VISUALIZER !== $chart->post_type || ! current_user_can( 'edit_post', $chart_id ) ) {
 			wp_die();
 		}
 
@@ -1037,7 +1038,7 @@ class Visualizer_Module_Chart extends Visualizer_Module {
 	 * Used as a fallback when the URL path has no recognisable file extension
 	 * (e.g. SharePoint, signed S3 URLs, or "download?id=…" endpoints).
 	 *
-	 * Uses wp_safe_remote_get() to block requests to private/loopback addresses,
+	 * Uses the shared remote-fetch policy to block non-public destinations,
 	 * and streams the response to a temp file so no body data is held in memory
 	 * regardless of whether the server honours the Range header.
 	 *
@@ -1056,7 +1057,7 @@ class Visualizer_Module_Chart extends Visualizer_Module {
 			return false;
 		}
 
-		$response = wp_safe_remote_get(
+		$response = Visualizer_Remote_Fetch::request(
 			$url,
 			array(
 				'timeout'    => 10,

--- a/classes/Visualizer/Remote/Fetch.php
+++ b/classes/Visualizer/Remote/Fetch.php
@@ -88,6 +88,8 @@ class Visualizer_Remote_Fetch {
 	 * @return string|WP_Error
 	 */
 	public static function download( $url, $args = array() ) {
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+
 		$tmpfile = wp_tempnam( (string) wp_parse_url( $url, PHP_URL_PATH ) );
 		if ( ! $tmpfile ) {
 			return new WP_Error( 'visualizer_temp_file', __( 'Could not create a temporary file.', 'visualizer' ) );

--- a/classes/Visualizer/Remote/Fetch.php
+++ b/classes/Visualizer/Remote/Fetch.php
@@ -10,7 +10,8 @@
  */
 class Visualizer_Remote_Fetch {
 
-	const MAX_REDIRECTS = 5;
+	const MAX_DOWNLOAD_BYTES = 10485760;
+	const MAX_REDIRECTS      = 5;
 
 	/**
 	 * Performs a request after validating every destination.
@@ -37,7 +38,8 @@ class Visualizer_Remote_Fetch {
 		}
 
 		for ( $redirect = 0; $redirect <= $redirects; $redirect++ ) {
-			$validated_url = self::validate_url( $url );
+			$ips           = array();
+			$validated_url = self::validate_url( $url, $ips );
 			if ( is_wp_error( $validated_url ) ) {
 				return $validated_url;
 			}
@@ -45,7 +47,12 @@ class Visualizer_Remote_Fetch {
 			$request_args                       = $args;
 			$request_args['redirection']        = 0;
 			$request_args['reject_unsafe_urls'] = true;
-			$response                           = wp_safe_remote_request( $validated_url, $request_args );
+
+			$pin      = self::pin_validated_addresses( $validated_url, $ips );
+			$response = wp_safe_remote_request( $validated_url, $request_args );
+			if ( $pin ) {
+				remove_action( 'http_api_curl', $pin );
+			}
 			if ( is_wp_error( $response ) ) {
 				return $response;
 			}
@@ -63,6 +70,7 @@ class Visualizer_Remote_Fetch {
 			$next_url = WP_Http::make_absolute_url( $location, $validated_url );
 			if ( ! self::same_origin( $validated_url, $next_url ) ) {
 				$args['headers'] = self::headers_for_cross_origin_redirect( isset( $args['headers'] ) ? $args['headers'] : array() );
+				unset( $args['cookies'] );
 			}
 
 			if ( 303 === $status || ( in_array( $status, array( 301, 302 ), true ) && 'POST' === $args['method'] ) ) {
@@ -93,9 +101,10 @@ class Visualizer_Remote_Fetch {
 			return new WP_Error( 'visualizer_temp_file', 'Could not create a temporary file.' );
 		}
 
-		$args['stream']   = true;
-		$args['filename'] = $tmpfile;
-		$response         = self::request( $url, $args );
+		$args['stream']              = true;
+		$args['filename']            = $tmpfile;
+		$args['limit_response_size'] = self::MAX_DOWNLOAD_BYTES;
+		$response                    = self::request( $url, $args );
 
 		if ( is_wp_error( $response ) ) {
 			wp_delete_file( $tmpfile );
@@ -105,6 +114,13 @@ class Visualizer_Remote_Fetch {
 		if ( 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {
 			wp_delete_file( $tmpfile );
 			return new WP_Error( 'visualizer_remote_status', 'The remote server returned an unexpected response.' );
+		}
+
+		// The transport truncates silently at the limit, so a file that reached it cannot be trusted.
+		clearstatcache( true, $tmpfile );
+		if ( filesize( $tmpfile ) >= self::MAX_DOWNLOAD_BYTES ) {
+			wp_delete_file( $tmpfile );
+			return new WP_Error( 'visualizer_remote_size', 'The remote file is too large to import.' );
 		}
 
 		return $tmpfile;
@@ -135,12 +151,41 @@ class Visualizer_Remote_Fetch {
 	}
 
 	/**
+	 * Binds the cURL transport to the addresses that passed validation.
+	 *
+	 * Without this the transport re-resolves the host on connect, letting a
+	 * rebinding nameserver answer with a private address after validation
+	 * passed. Covers the default cURL transport; the PHP streams fallback
+	 * keeps core's standard re-resolve behavior.
+	 *
+	 * @param string   $url Validated URL.
+	 * @param string[] $ips Validated addresses.
+	 * @return callable|null The registered hook to remove after dispatch, or null when there is nothing to pin.
+	 */
+	private static function pin_validated_addresses( $url, $ips ) {
+		if ( empty( $ips ) || ! defined( 'CURLOPT_RESOLVE' ) ) {
+			return null;
+		}
+
+		$parsed = wp_parse_url( $url );
+		$entry  = sprintf( '%s:%d:%s', strtolower( rtrim( $parsed['host'], '.' ) ), self::url_port( $parsed ), implode( ',', $ips ) );
+		$pin    = function ( $handle ) use ( $entry ) {
+			curl_setopt( $handle, CURLOPT_RESOLVE, array( $entry ) );
+		};
+		add_action( 'http_api_curl', $pin );
+
+		return $pin;
+	}
+
+	/**
 	 * Validates URL syntax and every address returned by DNS.
 	 *
-	 * @param string $url Remote URL.
+	 * @param string   $url Remote URL.
+	 * @param string[] $ips Filled with the validated addresses; stays empty when the host is exempt from the check.
 	 * @return string|WP_Error
 	 */
-	private static function validate_url( $url ) {
+	private static function validate_url( $url, &$ips = array() ) {
+		$ips           = array();
 		$validated_url = wp_http_validate_url( $url );
 		if ( false === $validated_url ) {
 			return new WP_Error( 'visualizer_invalid_remote_url', 'The remote URL is not allowed.' );

--- a/classes/Visualizer/Remote/Fetch.php
+++ b/classes/Visualizer/Remote/Fetch.php
@@ -59,7 +59,7 @@ class Visualizer_Remote_Fetch {
 			}
 
 			if ( $redirect === $redirects ) {
-				return new WP_Error( 'visualizer_too_many_redirects', __( 'The remote URL redirected too many times.', 'visualizer' ) );
+				return new WP_Error( 'visualizer_too_many_redirects', 'The remote URL redirected too many times.' );
 			}
 
 			$next_url = WP_Http::make_absolute_url( $location, $validated_url );
@@ -75,7 +75,7 @@ class Visualizer_Remote_Fetch {
 			$url = $next_url;
 		}
 
-		return new WP_Error( 'visualizer_remote_request', __( 'The remote request could not be completed.', 'visualizer' ) );
+		return new WP_Error( 'visualizer_remote_request', 'The remote request could not be completed.' );
 	}
 
 	/**
@@ -92,7 +92,7 @@ class Visualizer_Remote_Fetch {
 
 		$tmpfile = wp_tempnam( (string) wp_parse_url( $url, PHP_URL_PATH ) );
 		if ( ! $tmpfile ) {
-			return new WP_Error( 'visualizer_temp_file', __( 'Could not create a temporary file.', 'visualizer' ) );
+			return new WP_Error( 'visualizer_temp_file', 'Could not create a temporary file.' );
 		}
 
 		$args['stream']   = true;
@@ -106,7 +106,7 @@ class Visualizer_Remote_Fetch {
 
 		if ( 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {
 			wp_delete_file( $tmpfile );
-			return new WP_Error( 'visualizer_remote_status', __( 'The remote server returned an unexpected response.', 'visualizer' ) );
+			return new WP_Error( 'visualizer_remote_status', 'The remote server returned an unexpected response.' );
 		}
 
 		return $tmpfile;
@@ -121,7 +121,7 @@ class Visualizer_Remote_Fetch {
 	private static function enforce_request_policy( $args ) {
 		$args['method'] = strtoupper( (string) $args['method'] );
 		if ( ! in_array( $args['method'], array( 'GET', 'POST' ), true ) ) {
-			return new WP_Error( 'visualizer_remote_method', __( 'Only GET and POST remote requests are allowed.', 'visualizer' ) );
+			return new WP_Error( 'visualizer_remote_method', 'Only GET and POST remote requests are allowed.' );
 		}
 
 		$blocked_headers = array( 'connection', 'content-length', 'host', 'proxy-authorization', 'proxy-connection', 'te', 'trailer', 'transfer-encoding', 'upgrade' );
@@ -146,24 +146,24 @@ class Visualizer_Remote_Fetch {
 	private static function validate_url( $url ) {
 		$validated_url = wp_http_validate_url( $url );
 		if ( false === $validated_url ) {
-			return new WP_Error( 'visualizer_invalid_remote_url', __( 'The remote URL is not allowed.', 'visualizer' ) );
+			return new WP_Error( 'visualizer_invalid_remote_url', 'The remote URL is not allowed.' );
 		}
 
 		$parts = wp_parse_url( $validated_url );
 		$port  = isset( $parts['port'] ) ? (int) $parts['port'] : ( 'https' === strtolower( $parts['scheme'] ) ? 443 : 80 );
 		if ( ! in_array( $port, array( 80, 443, 8080 ), true ) ) {
-			return new WP_Error( 'visualizer_unsafe_remote_port', __( 'The remote URL uses a port that is not allowed.', 'visualizer' ) );
+			return new WP_Error( 'visualizer_unsafe_remote_port', 'The remote URL uses a port that is not allowed.' );
 		}
 
 		$host = strtolower( rtrim( (string) $parts['host'], '.' ) );
 		$ips  = self::resolve_host( $host );
 		if ( empty( $ips ) ) {
-			return new WP_Error( 'visualizer_remote_dns', __( 'The remote host could not be resolved.', 'visualizer' ) );
+			return new WP_Error( 'visualizer_remote_dns', 'The remote host could not be resolved.' );
 		}
 
 		foreach ( $ips as $ip ) {
 			if ( ! self::is_global_ip( $ip ) ) {
-				return new WP_Error( 'visualizer_unsafe_remote_url', __( 'The remote URL resolves to a non-public address.', 'visualizer' ) );
+				return new WP_Error( 'visualizer_unsafe_remote_url', 'The remote URL resolves to a non-public address.' );
 			}
 		}
 

--- a/classes/Visualizer/Remote/Fetch.php
+++ b/classes/Visualizer/Remote/Fetch.php
@@ -48,30 +48,13 @@ class Visualizer_Remote_Fetch {
 			$request_args['redirection']        = 0;
 			$request_args['reject_unsafe_urls'] = true;
 
-			$pin_ran = false;
-			$pin     = self::pin_validated_addresses( $validated_url, $ips, $pin_ran );
+			$pin      = self::pin_validated_addresses( $validated_url, $ips );
 			if ( is_wp_error( $pin ) ) {
 				return $pin;
 			}
-
-			// A `pre_http_request` short-circuit never reaches a transport, so the pin legitimately does not run.
-			$short_circuited = false;
-			$probe           = function ( $preempt ) use ( &$short_circuited ) {
-				$short_circuited = false !== $preempt;
-				return $preempt;
-			};
-			if ( $pin ) {
-				add_filter( 'pre_http_request', $probe, PHP_INT_MAX );
-			}
-
 			$response = wp_safe_remote_request( $validated_url, $request_args );
 			if ( $pin ) {
 				remove_action( 'http_api_curl', $pin );
-				remove_filter( 'pre_http_request', $probe, PHP_INT_MAX );
-				if ( ! $pin_ran && ! $short_circuited ) {
-					// A non-cURL transport dispatched the request without the pinned addresses; do not trust the response.
-					return new WP_Error( 'visualizer_remote_transport', 'The remote request did not use the pinned transport.' );
-				}
 			}
 			if ( is_wp_error( $response ) ) {
 				return $response;
@@ -184,11 +167,9 @@ class Visualizer_Remote_Fetch {
 	 *
 	 * @param string   $url Validated URL.
 	 * @param string[] $ips Validated addresses.
-	 * @param bool     $ran Set to true by the hook when the cURL transport actually dispatches the request.
 	 * @return callable|WP_Error|null The registered hook to remove after dispatch, an error when pinning is unavailable, or null for an IP literal or exempt host.
 	 */
-	private static function pin_validated_addresses( $url, $ips, &$ran = false ) {
-		$ran = false;
+	private static function pin_validated_addresses( $url, $ips ) {
 		if ( empty( $ips ) ) {
 			return null;
 		}
@@ -220,8 +201,7 @@ class Visualizer_Remote_Fetch {
 		}
 
 		$entry  = sprintf( '%s:%d:%s', strtolower( rtrim( $parsed['host'], '.' ) ), self::url_port( $parsed ), implode( ',', $addresses ) );
-		$pin    = function ( $handle ) use ( $entry, &$ran ) {
-			$ran = true;
+		$pin    = function ( $handle ) use ( $entry ) {
 			curl_setopt( $handle, CURLOPT_RESOLVE, array( $entry ) );
 		};
 		add_action( 'http_api_curl', $pin );

--- a/classes/Visualizer/Remote/Fetch.php
+++ b/classes/Visualizer/Remote/Fetch.php
@@ -1,0 +1,302 @@
+<?php
+/**
+ * Safe access to user-controlled remote resources.
+ *
+ * @package Visualizer
+ */
+
+/**
+ * Centralizes the network policy for remote chart imports.
+ */
+class Visualizer_Remote_Fetch {
+
+	const MAX_RESPONSE_SIZE = 10485760;
+	const MAX_REDIRECTS = 5;
+
+	/**
+	 * Performs a request after validating every destination.
+	 *
+	 * @param string               $url  Remote URL.
+	 * @param array<string, mixed> $args Optional WordPress HTTP arguments.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function request( $url, $args = array() ) {
+		$args = wp_parse_args(
+			$args,
+			array(
+				'method'              => 'GET',
+				'timeout'             => 15,
+				'limit_response_size' => self::MAX_RESPONSE_SIZE,
+			)
+		);
+
+		$redirects = isset( $args['redirection'] ) ? min( self::MAX_REDIRECTS, max( 0, (int) $args['redirection'] ) ) : self::MAX_REDIRECTS;
+		unset( $args['redirection'] );
+
+		$args = self::enforce_request_policy( $args );
+		if ( is_wp_error( $args ) ) {
+			return $args;
+		}
+
+		for ( $redirect = 0; $redirect <= $redirects; $redirect++ ) {
+			$validated_url = self::validate_url( $url );
+			if ( is_wp_error( $validated_url ) ) {
+				return $validated_url;
+			}
+
+			$request_args                       = $args;
+			$request_args['redirection']        = 0;
+			$request_args['reject_unsafe_urls'] = true;
+			$response                           = wp_safe_remote_request( $validated_url, $request_args );
+			if ( is_wp_error( $response ) ) {
+				return $response;
+			}
+
+			$status   = (int) wp_remote_retrieve_response_code( $response );
+			$location = wp_remote_retrieve_header( $response, 'location' );
+			if ( $status < 300 || $status > 399 || empty( $location ) ) {
+				return $response;
+			}
+
+			if ( $redirect === $redirects ) {
+				return new WP_Error( 'visualizer_too_many_redirects', __( 'The remote URL redirected too many times.', 'visualizer' ) );
+			}
+
+			$next_url = WP_Http::make_absolute_url( $location, $validated_url );
+			if ( ! self::same_origin( $validated_url, $next_url ) ) {
+				$args['headers'] = self::headers_for_cross_origin_redirect( isset( $args['headers'] ) ? $args['headers'] : array() );
+			}
+
+			if ( 303 === $status || ( in_array( $status, array( 301, 302 ), true ) && 'POST' === $args['method'] ) ) {
+				$args['method'] = 'GET';
+				unset( $args['body'] );
+			}
+
+			$url = $next_url;
+		}
+
+		return new WP_Error( 'visualizer_remote_request', __( 'The remote request could not be completed.', 'visualizer' ) );
+	}
+
+	/**
+	 * Downloads a remote resource to a temporary file.
+	 *
+	 * The caller is responsible for deleting the returned file.
+	 *
+	 * @param string               $url  Remote URL.
+	 * @param array<string, mixed> $args Optional WordPress HTTP arguments.
+	 * @return string|WP_Error
+	 */
+	public static function download( $url, $args = array() ) {
+		$tmpfile = wp_tempnam( (string) wp_parse_url( $url, PHP_URL_PATH ) );
+		if ( ! $tmpfile ) {
+			return new WP_Error( 'visualizer_temp_file', __( 'Could not create a temporary file.', 'visualizer' ) );
+		}
+
+		$args['stream']   = true;
+		$args['filename'] = $tmpfile;
+		$response         = self::request( $url, $args );
+
+		if ( is_wp_error( $response ) ) {
+			wp_delete_file( $tmpfile );
+			return $response;
+		}
+
+		if ( 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {
+			wp_delete_file( $tmpfile );
+			return new WP_Error( 'visualizer_remote_status', __( 'The remote server returned an unexpected response.', 'visualizer' ) );
+		}
+
+		return $tmpfile;
+	}
+
+	/**
+	 * Applies method and header restrictions.
+	 *
+	 * @param array<string, mixed> $args HTTP arguments.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	private static function enforce_request_policy( $args ) {
+		$args['method'] = strtoupper( (string) $args['method'] );
+		if ( ! in_array( $args['method'], array( 'GET', 'POST' ), true ) ) {
+			return new WP_Error( 'visualizer_remote_method', __( 'Only GET and POST remote requests are allowed.', 'visualizer' ) );
+		}
+
+		$blocked_headers = array( 'connection', 'content-length', 'host', 'proxy-authorization', 'proxy-connection', 'te', 'trailer', 'transfer-encoding', 'upgrade' );
+		foreach ( isset( $args['headers'] ) ? $args['headers'] : array() as $name => $value ) {
+			if ( in_array( strtolower( (string) $name ), $blocked_headers, true ) ) {
+				unset( $args['headers'][ $name ] );
+			}
+		}
+
+		$args['timeout']             = min( 30, max( 1, (int) $args['timeout'] ) );
+		$args['limit_response_size'] = min( self::MAX_RESPONSE_SIZE, max( 1, (int) $args['limit_response_size'] ) );
+
+		return $args;
+	}
+
+	/**
+	 * Validates URL syntax and every address returned by DNS.
+	 *
+	 * @param string $url Remote URL.
+	 * @return string|WP_Error
+	 */
+	private static function validate_url( $url ) {
+		$validated_url = wp_http_validate_url( $url );
+		if ( false === $validated_url ) {
+			return new WP_Error( 'visualizer_invalid_remote_url', __( 'The remote URL is not allowed.', 'visualizer' ) );
+		}
+
+		$parts = wp_parse_url( $validated_url );
+		$port  = isset( $parts['port'] ) ? (int) $parts['port'] : ( 'https' === strtolower( $parts['scheme'] ) ? 443 : 80 );
+		if ( ! in_array( $port, array( 80, 443, 8080 ), true ) ) {
+			return new WP_Error( 'visualizer_unsafe_remote_port', __( 'The remote URL uses a port that is not allowed.', 'visualizer' ) );
+		}
+
+		$host = strtolower( rtrim( (string) $parts['host'], '.' ) );
+		$ips  = self::resolve_host( $host );
+		if ( empty( $ips ) ) {
+			return new WP_Error( 'visualizer_remote_dns', __( 'The remote host could not be resolved.', 'visualizer' ) );
+		}
+
+		foreach ( $ips as $ip ) {
+			if ( ! self::is_global_ip( $ip ) ) {
+				return new WP_Error( 'visualizer_unsafe_remote_url', __( 'The remote URL resolves to a non-public address.', 'visualizer' ) );
+			}
+		}
+
+		return $validated_url;
+	}
+
+	/**
+	 * Resolves every IPv4 and IPv6 address for a host.
+	 *
+	 * @param string $host Host name or IP literal.
+	 * @return string[]
+	 */
+	private static function resolve_host( $host ) {
+		if ( filter_var( $host, FILTER_VALIDATE_IP ) ) {
+			return array( $host );
+		}
+
+		$ips = array();
+		if ( function_exists( 'dns_get_record' ) ) {
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- DNS failures are handled below.
+			$records = @dns_get_record( $host, DNS_A | DNS_AAAA );
+			foreach ( is_array( $records ) ? $records : array() as $record ) {
+				if ( ! empty( $record['ip'] ) ) {
+					$ips[] = $record['ip'];
+				} elseif ( ! empty( $record['ipv6'] ) ) {
+					$ips[] = $record['ipv6'];
+				}
+			}
+		}
+
+		if ( empty( $ips ) ) {
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- DNS failures are handled by returning no addresses.
+			$ipv4 = @gethostbynamel( $host );
+			$ips  = is_array( $ipv4 ) ? $ipv4 : array();
+		}
+
+		return array_values( array_unique( $ips ) );
+	}
+
+	/**
+	 * Whether an address is globally routable.
+	 *
+	 * @param string $ip IP address.
+	 * @return bool
+	 */
+	private static function is_global_ip( $ip ) {
+		if ( self::ip_in_range( $ip, '::ffff:0:0/96' ) ) {
+			$packed = inet_pton( $ip );
+			$ip     = inet_ntop( substr( $packed, 12 ) );
+		}
+
+		if ( false === filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ) ) {
+			return false;
+		}
+
+		$ranges = false !== strpos( $ip, ':' )
+			? array( 'fc00::/7', 'fe80::/10', 'ff00::/8' )
+			: array( '100.64.0.0/10', '192.0.0.0/24', '192.0.2.0/24', '198.18.0.0/15', '198.51.100.0/24', '203.0.113.0/24', '224.0.0.0/4', '240.0.0.0/4' );
+
+		foreach ( $ranges as $range ) {
+			if ( self::ip_in_range( $ip, $range ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Checks whether an IP belongs to a CIDR range.
+	 *
+	 * @param string $ip   IP address.
+	 * @param string $cidr CIDR range.
+	 * @return bool
+	 */
+	private static function ip_in_range( $ip, $cidr ) {
+		list( $network, $prefix ) = explode( '/', $cidr, 2 );
+		$address                  = inet_pton( $ip );
+		$network                  = inet_pton( $network );
+		if ( false === $address || false === $network || strlen( $address ) !== strlen( $network ) ) {
+			return false;
+		}
+
+		$bytes = intdiv( (int) $prefix, 8 );
+		$bits  = (int) $prefix % 8;
+		if ( substr( $address, 0, $bytes ) !== substr( $network, 0, $bytes ) ) {
+			return false;
+		}
+
+		return 0 === $bits || ( ord( $address[ $bytes ] ) & ( 0xff << ( 8 - $bits ) ) ) === ( ord( $network[ $bytes ] ) & ( 0xff << ( 8 - $bits ) ) );
+	}
+
+	/**
+	 * Whether two URLs share scheme, host, and port.
+	 *
+	 * @param string $first  First URL.
+	 * @param string $second Second URL.
+	 * @return bool
+	 */
+	private static function same_origin( $first, $second ) {
+		$first  = wp_parse_url( $first );
+		$second = wp_parse_url( $second );
+		if ( ! is_array( $first ) || ! is_array( $second ) || empty( $first['scheme'] ) || empty( $first['host'] ) || empty( $second['scheme'] ) || empty( $second['host'] ) ) {
+			return false;
+		}
+
+		return strtolower( $first['scheme'] ) === strtolower( $second['scheme'] )
+			&& strtolower( $first['host'] ) === strtolower( $second['host'] )
+			&& self::url_port( $first ) === self::url_port( $second );
+	}
+
+	/**
+	 * Gets an explicit or scheme-default URL port.
+	 *
+	 * @param array<string, mixed> $url Parsed URL.
+	 * @return int
+	 */
+	private static function url_port( $url ) {
+		return isset( $url['port'] ) ? (int) $url['port'] : ( 'https' === strtolower( $url['scheme'] ) ? 443 : 80 );
+	}
+
+	/**
+	 * Retains only non-sensitive headers across an origin change.
+	 *
+	 * @param array<string, mixed> $headers Request headers.
+	 * @return array<string, mixed>
+	 */
+	private static function headers_for_cross_origin_redirect( $headers ) {
+		$allowed = array( 'accept', 'accept-encoding', 'range', 'user-agent' );
+		return array_filter(
+			$headers,
+			function ( $value, $name ) use ( $allowed ) {
+				return in_array( strtolower( (string) $name ), $allowed, true );
+			},
+			ARRAY_FILTER_USE_BOTH
+		);
+	}
+}

--- a/classes/Visualizer/Remote/Fetch.php
+++ b/classes/Visualizer/Remote/Fetch.php
@@ -49,6 +49,9 @@ class Visualizer_Remote_Fetch {
 			$request_args['reject_unsafe_urls'] = true;
 
 			$pin      = self::pin_validated_addresses( $validated_url, $ips );
+			if ( is_wp_error( $pin ) ) {
+				return $pin;
+			}
 			$response = wp_safe_remote_request( $validated_url, $request_args );
 			if ( $pin ) {
 				remove_action( 'http_api_curl', $pin );
@@ -96,6 +99,11 @@ class Visualizer_Remote_Fetch {
 	public static function download( $url, $args = array() ) {
 		require_once ABSPATH . 'wp-admin/includes/file.php';
 
+		$max_bytes = isset( $args['limit_response_size'] ) ? (int) $args['limit_response_size'] : self::MAX_DOWNLOAD_BYTES;
+		if ( $max_bytes < 1 ) {
+			return new WP_Error( 'visualizer_remote_size', 'The remote file size limit is invalid.' );
+		}
+
 		$tmpfile = wp_tempnam( (string) wp_parse_url( $url, PHP_URL_PATH ) );
 		if ( ! $tmpfile ) {
 			return new WP_Error( 'visualizer_temp_file', 'Could not create a temporary file.' );
@@ -103,7 +111,7 @@ class Visualizer_Remote_Fetch {
 
 		$args['stream']              = true;
 		$args['filename']            = $tmpfile;
-		$args['limit_response_size'] = self::MAX_DOWNLOAD_BYTES;
+		$args['limit_response_size'] = $max_bytes < PHP_INT_MAX ? $max_bytes + 1 : $max_bytes;
 		$response                    = self::request( $url, $args );
 
 		if ( is_wp_error( $response ) ) {
@@ -116,9 +124,9 @@ class Visualizer_Remote_Fetch {
 			return new WP_Error( 'visualizer_remote_status', 'The remote server returned an unexpected response.' );
 		}
 
-		// The transport truncates silently at the limit, so a file that reached it cannot be trusted.
+		// Download one extra byte so an exactly-at-limit file remains valid.
 		clearstatcache( true, $tmpfile );
-		if ( filesize( $tmpfile ) >= self::MAX_DOWNLOAD_BYTES ) {
+		if ( filesize( $tmpfile ) > $max_bytes ) {
 			wp_delete_file( $tmpfile );
 			return new WP_Error( 'visualizer_remote_size', 'The remote file is too large to import.' );
 		}
@@ -155,20 +163,44 @@ class Visualizer_Remote_Fetch {
 	 *
 	 * Without this the transport re-resolves the host on connect, letting a
 	 * rebinding nameserver answer with a private address after validation
-	 * passed. Covers the default cURL transport; the PHP streams fallback
-	 * keeps core's standard re-resolve behavior.
+	 * passed. Hostname requests fail closed when cURL pinning is unavailable.
 	 *
 	 * @param string   $url Validated URL.
 	 * @param string[] $ips Validated addresses.
-	 * @return callable|null The registered hook to remove after dispatch, or null when there is nothing to pin.
+	 * @return callable|WP_Error|null The registered hook to remove after dispatch, an error when pinning is unavailable, or null for an IP literal or exempt host.
 	 */
 	private static function pin_validated_addresses( $url, $ips ) {
-		if ( empty( $ips ) || ! defined( 'CURLOPT_RESOLVE' ) ) {
+		if ( empty( $ips ) ) {
 			return null;
 		}
 
 		$parsed = wp_parse_url( $url );
-		$entry  = sprintf( '%s:%d:%s', strtolower( rtrim( $parsed['host'], '.' ) ), self::url_port( $parsed ), implode( ',', $ips ) );
+		if ( filter_var( rtrim( $parsed['host'], '.' ), FILTER_VALIDATE_IP ) ) {
+			return null;
+		}
+
+		if ( ! function_exists( 'curl_init' ) || ! function_exists( 'curl_exec' ) || ! defined( 'CURLOPT_RESOLVE' ) ) {
+			return new WP_Error( 'visualizer_remote_transport', 'The remote host cannot be fetched securely on this server.' );
+		}
+
+		if ( 'https' === strtolower( $parsed['scheme'] ) ) {
+			$curl = curl_version();
+			if ( empty( $curl['features'] ) || ! defined( 'CURL_VERSION_SSL' ) || ! ( $curl['features'] & CURL_VERSION_SSL ) ) {
+				return new WP_Error( 'visualizer_remote_transport', 'The remote host cannot be fetched securely on this server.' );
+			}
+		}
+
+		$proxy = new WP_HTTP_Proxy();
+		if ( $proxy->is_enabled() && $proxy->send_through_proxy( $url ) ) {
+			return new WP_Error( 'visualizer_remote_transport', 'The remote host cannot be fetched securely through the configured proxy.' );
+		}
+
+		$addresses = array();
+		foreach ( $ips as $ip ) {
+			$addresses[] = filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 ) ? '[' . $ip . ']' : $ip;
+		}
+
+		$entry  = sprintf( '%s:%d:%s', strtolower( rtrim( $parsed['host'], '.' ) ), self::url_port( $parsed ), implode( ',', $addresses ) );
 		$pin    = function ( $handle ) use ( $entry ) {
 			curl_setopt( $handle, CURLOPT_RESOLVE, array( $entry ) );
 		};

--- a/classes/Visualizer/Remote/Fetch.php
+++ b/classes/Visualizer/Remote/Fetch.php
@@ -147,7 +147,14 @@ class Visualizer_Remote_Fetch {
 		}
 
 		$host = strtolower( rtrim( (string) wp_parse_url( $validated_url, PHP_URL_HOST ), '.' ) );
-		$ips  = self::resolve_host( $host );
+
+		// Mirror core's same-host exemption so media library URLs import on hosts that resolve internally.
+		$home_host = strtolower( rtrim( (string) wp_parse_url( get_option( 'home' ), PHP_URL_HOST ), '.' ) );
+		if ( $host === $home_host ) {
+			return $validated_url;
+		}
+
+		$ips = self::resolve_host( $host );
 		if ( empty( $ips ) ) {
 			return new WP_Error( 'visualizer_remote_dns', 'The remote host could not be resolved.' );
 		}

--- a/classes/Visualizer/Remote/Fetch.php
+++ b/classes/Visualizer/Remote/Fetch.php
@@ -10,7 +10,6 @@
  */
 class Visualizer_Remote_Fetch {
 
-	const MAX_RESPONSE_SIZE = 10485760;
 	const MAX_REDIRECTS = 5;
 
 	/**
@@ -24,9 +23,8 @@ class Visualizer_Remote_Fetch {
 		$args = wp_parse_args(
 			$args,
 			array(
-				'method'              => 'GET',
-				'timeout'             => 15,
-				'limit_response_size' => self::MAX_RESPONSE_SIZE,
+				'method'  => 'GET',
+				'timeout' => 15,
 			)
 		);
 
@@ -131,8 +129,7 @@ class Visualizer_Remote_Fetch {
 			}
 		}
 
-		$args['timeout']             = min( 30, max( 1, (int) $args['timeout'] ) );
-		$args['limit_response_size'] = min( self::MAX_RESPONSE_SIZE, max( 1, (int) $args['limit_response_size'] ) );
+		$args['timeout'] = min( 30, max( 1, (int) $args['timeout'] ) );
 
 		return $args;
 	}

--- a/classes/Visualizer/Remote/Fetch.php
+++ b/classes/Visualizer/Remote/Fetch.php
@@ -149,13 +149,7 @@ class Visualizer_Remote_Fetch {
 			return new WP_Error( 'visualizer_invalid_remote_url', 'The remote URL is not allowed.' );
 		}
 
-		$parts = wp_parse_url( $validated_url );
-		$port  = isset( $parts['port'] ) ? (int) $parts['port'] : ( 'https' === strtolower( $parts['scheme'] ) ? 443 : 80 );
-		if ( ! in_array( $port, array( 80, 443, 8080 ), true ) ) {
-			return new WP_Error( 'visualizer_unsafe_remote_port', 'The remote URL uses a port that is not allowed.' );
-		}
-
-		$host = strtolower( rtrim( (string) $parts['host'], '.' ) );
+		$host = strtolower( rtrim( (string) wp_parse_url( $validated_url, PHP_URL_HOST ), '.' ) );
 		$ips  = self::resolve_host( $host );
 		if ( empty( $ips ) ) {
 			return new WP_Error( 'visualizer_remote_dns', 'The remote host could not be resolved.' );
@@ -221,7 +215,7 @@ class Visualizer_Remote_Fetch {
 
 		$ranges = false !== strpos( $ip, ':' )
 			? array( 'fc00::/7', 'fe80::/10', 'ff00::/8' )
-			: array( '100.64.0.0/10', '192.0.0.0/24', '192.0.2.0/24', '198.18.0.0/15', '198.51.100.0/24', '203.0.113.0/24', '224.0.0.0/4', '240.0.0.0/4' );
+			: array( '100.64.0.0/10', '192.0.0.0/24', '192.0.2.0/24', '198.18.0.0/15', '198.51.100.0/24', '203.0.113.0/24', '224.0.0.0/4' );
 
 		foreach ( $ranges as $range ) {
 			if ( self::ip_in_range( $ip, $range ) ) {

--- a/classes/Visualizer/Remote/Fetch.php
+++ b/classes/Visualizer/Remote/Fetch.php
@@ -48,13 +48,30 @@ class Visualizer_Remote_Fetch {
 			$request_args['redirection']        = 0;
 			$request_args['reject_unsafe_urls'] = true;
 
-			$pin      = self::pin_validated_addresses( $validated_url, $ips );
+			$pin_ran = false;
+			$pin     = self::pin_validated_addresses( $validated_url, $ips, $pin_ran );
 			if ( is_wp_error( $pin ) ) {
 				return $pin;
 			}
+
+			// A `pre_http_request` short-circuit never reaches a transport, so the pin legitimately does not run.
+			$short_circuited = false;
+			$probe           = function ( $preempt ) use ( &$short_circuited ) {
+				$short_circuited = false !== $preempt;
+				return $preempt;
+			};
+			if ( $pin ) {
+				add_filter( 'pre_http_request', $probe, PHP_INT_MAX );
+			}
+
 			$response = wp_safe_remote_request( $validated_url, $request_args );
 			if ( $pin ) {
 				remove_action( 'http_api_curl', $pin );
+				remove_filter( 'pre_http_request', $probe, PHP_INT_MAX );
+				if ( ! $pin_ran && ! $short_circuited ) {
+					// A non-cURL transport dispatched the request without the pinned addresses; do not trust the response.
+					return new WP_Error( 'visualizer_remote_transport', 'The remote request did not use the pinned transport.' );
+				}
 			}
 			if ( is_wp_error( $response ) ) {
 				return $response;
@@ -167,9 +184,11 @@ class Visualizer_Remote_Fetch {
 	 *
 	 * @param string   $url Validated URL.
 	 * @param string[] $ips Validated addresses.
+	 * @param bool     $ran Set to true by the hook when the cURL transport actually dispatches the request.
 	 * @return callable|WP_Error|null The registered hook to remove after dispatch, an error when pinning is unavailable, or null for an IP literal or exempt host.
 	 */
-	private static function pin_validated_addresses( $url, $ips ) {
+	private static function pin_validated_addresses( $url, $ips, &$ran = false ) {
+		$ran = false;
 		if ( empty( $ips ) ) {
 			return null;
 		}
@@ -201,7 +220,8 @@ class Visualizer_Remote_Fetch {
 		}
 
 		$entry  = sprintf( '%s:%d:%s', strtolower( rtrim( $parsed['host'], '.' ) ), self::url_port( $parsed ), implode( ',', $addresses ) );
-		$pin    = function ( $handle ) use ( $entry ) {
+		$pin    = function ( $handle ) use ( $entry, &$ran ) {
+			$ran = true;
 			curl_setopt( $handle, CURLOPT_RESOLVE, array( $entry ) );
 		};
 		add_action( 'http_api_curl', $pin );

--- a/classes/Visualizer/Source/Csv.php
+++ b/classes/Visualizer/Source/Csv.php
@@ -141,22 +141,27 @@ class Visualizer_Source_Csv extends Visualizer_Source {
 
 		// read file and fill arrays
 		$handle = $this->_get_file_handle();
-		if ( $handle ) {
-			// fetch series
-			if ( ! $this->_fetchSeries( $handle ) ) {
-				return false;
+		if ( ! $handle ) {
+			if ( empty( $this->_error ) ) {
+				$this->_error = esc_html__( 'The file could not be opened. Please try again.', 'visualizer' );
 			}
-
-			// fetch data
-			$data = fgetcsv( $handle, 0, VISUALIZER_CSV_DELIMITER, VISUALIZER_CSV_ENCLOSURE );
-			while ( $data !== false ) {
-				$this->_data[] = $this->_normalizeData( $data );
-				$data = fgetcsv( $handle, 0, VISUALIZER_CSV_DELIMITER, VISUALIZER_CSV_ENCLOSURE );
-			}
-
-			// close file handle
-			fclose( $handle );
+			return false;
 		}
+
+		// fetch series
+		if ( ! $this->_fetchSeries( $handle ) ) {
+			return false;
+		}
+
+		// fetch data
+		$data = fgetcsv( $handle, 0, VISUALIZER_CSV_DELIMITER, VISUALIZER_CSV_ENCLOSURE );
+		while ( $data !== false ) {
+			$this->_data[] = $this->_normalizeData( $data );
+			$data = fgetcsv( $handle, 0, VISUALIZER_CSV_DELIMITER, VISUALIZER_CSV_ENCLOSURE );
+		}
+
+		// close file handle
+		fclose( $handle );
 
 		return true;
 	}

--- a/classes/Visualizer/Source/Csv.php
+++ b/classes/Visualizer/Source/Csv.php
@@ -117,7 +117,7 @@ class Visualizer_Source_Csv extends Visualizer_Source {
 	 *
 	 * @access protected
 	 * @param string $filename Optional file name to get handle. If omitted, $_filename is used.
-	 * @return resource File handle resource on success, otherwise FALSE.
+	 * @return resource|false File handle resource on success, otherwise FALSE.
 	 */
 	protected function _get_file_handle( $filename = false ) {
 		// open file and return handle

--- a/classes/Visualizer/Source/Csv.php
+++ b/classes/Visualizer/Source/Csv.php
@@ -150,6 +150,7 @@ class Visualizer_Source_Csv extends Visualizer_Source {
 
 		// fetch series
 		if ( ! $this->_fetchSeries( $handle ) ) {
+			fclose( $handle );
 			return false;
 		}
 

--- a/classes/Visualizer/Source/Csv/Remote.php
+++ b/classes/Visualizer/Source/Csv/Remote.php
@@ -162,6 +162,7 @@ class Visualizer_Source_Csv_Remote extends Visualizer_Source_Csv {
 
 		$tmpfile = Visualizer_Remote_Fetch::download( $this->_filename );
 		if ( is_wp_error( $tmpfile ) ) {
+			$this->_error = esc_html__( 'Could not download the file. Please check the URL and try again.', 'visualizer' );
 			return false;
 		}
 

--- a/classes/Visualizer/Source/Csv/Remote.php
+++ b/classes/Visualizer/Source/Csv/Remote.php
@@ -30,12 +30,12 @@
 class Visualizer_Source_Csv_Remote extends Visualizer_Source_Csv {
 
 	/**
-	 * Temporary file name used when allow_url_fopen option is disabled.
+	 * Path to the safely downloaded temporary file.
 	 *
 	 * @since 1.4.2
 	 *
 	 * @access private
-	 * @var string
+	 * @var string|false
 	 */
 	private $_tmpfile = false;
 
@@ -130,35 +130,42 @@ class Visualizer_Source_Csv_Remote extends Visualizer_Source_Csv {
 	}
 
 	/**
+	 * Fetches the remote file and removes its temporary copy.
+	 *
+	 * @access public
+	 * @return boolean TRUE on success, otherwise FALSE.
+	 */
+	public function fetch() {
+		$result = parent::fetch();
+
+		if ( $this->_tmpfile && is_file( $this->_tmpfile ) ) {
+			wp_delete_file( $this->_tmpfile );
+			$this->_tmpfile = false;
+		}
+
+		return $result;
+	}
+
+	/**
 	 * Returns file handle to fetch data from.
 	 *
 	 * @since 1.4.2
 	 *
 	 * @access protected
-	 * @staticvar boolean $allow_url_fopen Determines whether or not allow_url_fopen option is enabled.
 	 * @param string $filename Optional file name to get handle. If omitted, $_filename is used.
-	 * @return resource File handle resource on success, otherwise FALSE.
+	 * @return resource|false File handle resource on success, otherwise FALSE.
 	 */
 	protected function _get_file_handle( $filename = false ) {
-		static $allow_url_fopen = null;
-
-		if ( ! is_wp_error( $this->_tmpfile ) && $this->_tmpfile && is_readable( $this->_tmpfile ) ) {
+		if ( $this->_tmpfile && is_readable( $this->_tmpfile ) ) {
 			return parent::_get_file_handle( $this->_tmpfile );
 		}
 
-		if ( is_null( $allow_url_fopen ) ) {
-			$allow_url_fopen = filter_var( ini_get( 'allow_url_fopen' ), FILTER_VALIDATE_BOOLEAN );
+		$tmpfile = Visualizer_Remote_Fetch::download( $this->_filename );
+		if ( is_wp_error( $tmpfile ) ) {
+			return false;
 		}
 
-		$scheme = parse_url( $this->_filename, PHP_URL_SCHEME );
-		if ( $allow_url_fopen && in_array( $scheme, stream_get_wrappers(), true ) ) {
-			return parent::_get_file_handle( $filename );
-		}
-
-		require_once ABSPATH . 'wp-admin/includes/file.php';
-
-		$this->_tmpfile = download_url( $this->_filename );
-
-		return ! is_wp_error( $this->_tmpfile ) ? parent::_get_file_handle( $this->_tmpfile ) : false;
+		$this->_tmpfile = $tmpfile;
+		return parent::_get_file_handle( $this->_tmpfile );
 	}
 }

--- a/classes/Visualizer/Source/Json.php
+++ b/classes/Visualizer/Source/Json.php
@@ -122,7 +122,7 @@ class Visualizer_Source_Json extends Visualizer_Source {
 		if ( isset( $this->_args['additional_headers'] ) ) {
 			$this->_additional_headers = $this->_args['additional_headers'];
 		}
-		do_action( 'themeisle_log_event', Visualizer_Plugin::NAME, sprintf( 'Constructor called for params = %s', print_r( $params, true ) ), 'debug', __FILE__, __LINE__ );
+		do_action( 'themeisle_log_event', Visualizer_Plugin::NAME, 'JSON source initialized.', 'debug', __FILE__, __LINE__ );
 	}
 
 	/**
@@ -283,7 +283,7 @@ class Visualizer_Source_Json extends Visualizer_Source {
 
 		$this->_data = $data;
 
-		do_action( 'themeisle_log_event', Visualizer_Plugin::NAME, sprintf( 'Parsed data endpoint %s with root %s is %s', $this->_url, $this->_root, print_r( $data, true ) ), 'debug', __FILE__, __LINE__ );
+		do_action( 'themeisle_log_event', Visualizer_Plugin::NAME, 'JSON endpoint data parsed.', 'debug', __FILE__, __LINE__ );
 
 		return true;
 	}
@@ -379,7 +379,7 @@ class Visualizer_Source_Json extends Visualizer_Source {
 			}
 		}
 		$roots = array_unique( $root );
-		do_action( 'themeisle_log_event', Visualizer_Plugin::NAME, sprintf( 'Roots found for %s = %s', $this->_url, print_r( $roots, true ) ), 'debug', __FILE__, __LINE__ );
+		do_action( 'themeisle_log_event', Visualizer_Plugin::NAME, 'JSON root elements parsed.', 'debug', __FILE__, __LINE__ );
 		return $roots;
 	}
 
@@ -397,7 +397,8 @@ class Visualizer_Source_Json extends Visualizer_Source {
 
 		$response = $this->connect( $url );
 		if ( is_wp_error( $response ) || ! in_array( intval( $response['response']['code'] ), array( 200, 201 ), true ) ) {
-			do_action( 'themeisle_log_event', Visualizer_Plugin::NAME, sprintf( 'Error while fetching JSON endpoint %s = %s', $url, print_r( $response, true ) ), 'error', __FILE__, __LINE__ );
+			$error_code = is_wp_error( $response ) ? $response->get_error_code() : (string) wp_remote_retrieve_response_code( $response );
+			do_action( 'themeisle_log_event', Visualizer_Plugin::NAME, sprintf( 'Error while fetching JSON endpoint: %s', $error_code ), 'error', __FILE__, __LINE__ );
 			return null;
 		}
 
@@ -408,7 +409,7 @@ class Visualizer_Source_Json extends Visualizer_Source {
 		$response_body = preg_replace( "/^$bom/", '', $response_body );
 		$array  = apply_filters( 'visualizer_json_massage_data', json_decode( $response_body, true ), $url );
 
-		do_action( 'themeisle_log_event', Visualizer_Plugin::NAME, sprintf( 'JSON array for the endpoint is %s = ', print_r( $array, true ) ), 'debug', __FILE__, __LINE__ );
+		do_action( 'themeisle_log_event', Visualizer_Plugin::NAME, 'JSON response decoded.', 'debug', __FILE__, __LINE__ );
 
 		return $array;
 	}
@@ -467,8 +468,8 @@ class Visualizer_Source_Json extends Visualizer_Source {
 			$args['headers']['X-Visualizer-Token'] = $token;
 		}
 
-		do_action( 'themeisle_log_event', Visualizer_Plugin::NAME, sprintf( 'Connecting to %s with args = %s ', $url, print_r( $args, true ) ), 'debug', __FILE__, __LINE__ );
-		return wp_safe_remote_request( $url, $args );
+		do_action( 'themeisle_log_event', Visualizer_Plugin::NAME, sprintf( 'Connecting to JSON endpoint with method %s', $args['method'] ), 'debug', __FILE__, __LINE__ );
+		return Visualizer_Remote_Fetch::request( $url, $args );
 	}
 
 	/**

--- a/classes/Visualizer/Source/Xlsx.php
+++ b/classes/Visualizer/Source/Xlsx.php
@@ -55,8 +55,13 @@ class Visualizer_Source_Xlsx extends Visualizer_Source {
 		}
 
 		$reader = \OpenSpout\Reader\Common\Creator\ReaderEntityFactory::createXLSXReader();
+		$file_path = $this->_get_file_path();
+		if ( ! $file_path ) {
+			return false;
+		}
+
 		try {
-			$reader->open( $this->_get_file_path() );
+			$reader->open( $file_path );
 
 			$all_rows = array();
 			foreach ( $reader->getSheetIterator() as $sheet ) {

--- a/classes/Visualizer/Source/Xlsx/Remote.php
+++ b/classes/Visualizer/Source/Xlsx/Remote.php
@@ -93,9 +93,15 @@ class Visualizer_Source_Xlsx_Remote extends Visualizer_Source_Xlsx {
 			return $this->_tmpfile;
 		}
 
-		$tmpfile = Visualizer_Remote_Fetch::download( $this->_filename );
+		$max_bytes = (int) apply_filters( 'visualizer_xlsx_max_filesize', 10 * 1024 * 1024 );
+		$tmpfile   = Visualizer_Remote_Fetch::download(
+			$this->_filename,
+			array( 'limit_response_size' => $max_bytes )
+		);
 		if ( is_wp_error( $tmpfile ) ) {
-			$this->_error   = esc_html__( 'Could not download the XLSX file. Please check the URL and try again.', 'visualizer' );
+			$this->_error = 'visualizer_remote_size' === $tmpfile->get_error_code()
+				? esc_html__( 'The XLSX file exceeds the maximum allowed size and cannot be imported.', 'visualizer' )
+				: esc_html__( 'Could not download the XLSX file. Please check the URL and try again.', 'visualizer' );
 			return false;
 		}
 		$this->_tmpfile = $tmpfile;
@@ -103,18 +109,6 @@ class Visualizer_Source_Xlsx_Remote extends Visualizer_Source_Xlsx {
 		if ( ! is_file( $this->_tmpfile ) ) {
 			$this->_tmpfile = false;
 			$this->_error   = esc_html__( 'Could not access the downloaded XLSX file. Please try again.', 'visualizer' );
-			return false;
-		}
-
-		// Maximum allowed file size in bytes. Default 10 MB; override via filter.
-		$max_bytes = (int) apply_filters( 'visualizer_xlsx_max_filesize', 10 * 1024 * 1024 );
-		if ( filesize( $this->_tmpfile ) > $max_bytes ) {
-			wp_delete_file( $this->_tmpfile );
-			$this->_tmpfile = false;
-			$this->_error   = esc_html__(
-				'The XLSX file exceeds the maximum allowed size and cannot be imported.',
-				'visualizer'
-			);
 			return false;
 		}
 

--- a/classes/Visualizer/Source/Xlsx/Remote.php
+++ b/classes/Visualizer/Source/Xlsx/Remote.php
@@ -86,41 +86,36 @@ class Visualizer_Source_Xlsx_Remote extends Visualizer_Source_Xlsx {
 	 * guarding against ZIP-bomb and DoS attacks.
 	 *
 	 * @access protected
-	 * @return string Path to the temporary file, or the original URL if download failed.
+	 * @return string|false Path to the temporary file, or false if download failed.
 	 */
 	protected function _get_file_path() {
-		if ( $this->_tmpfile && ! is_wp_error( $this->_tmpfile ) && is_readable( $this->_tmpfile ) ) {
+		if ( $this->_tmpfile && is_readable( $this->_tmpfile ) ) {
 			return $this->_tmpfile;
 		}
 
-		require_once ABSPATH . 'wp-admin/includes/file.php';
-
-		$this->_tmpfile = download_url( $this->_filename );
-
-		if ( is_wp_error( $this->_tmpfile ) ) {
+		$tmpfile = Visualizer_Remote_Fetch::download( $this->_filename );
+		if ( is_wp_error( $tmpfile ) ) {
 			$this->_error   = esc_html__( 'Could not download the XLSX file. Please check the URL and try again.', 'visualizer' );
-			$this->_tmpfile = false;
-			// Return the original URL so the parent's open() call will fail
-			// gracefully and set an error rather than throwing a PHP error.
-			return $this->_filename;
+			return false;
 		}
+		$this->_tmpfile = $tmpfile;
 
 		if ( ! is_file( $this->_tmpfile ) ) {
 			$this->_tmpfile = false;
 			$this->_error   = esc_html__( 'Could not access the downloaded XLSX file. Please try again.', 'visualizer' );
-			return $this->_filename;
+			return false;
 		}
 
 		// Maximum allowed file size in bytes. Default 10 MB; override via filter.
 		$max_bytes = (int) apply_filters( 'visualizer_xlsx_max_filesize', 10 * 1024 * 1024 );
 		if ( filesize( $this->_tmpfile ) > $max_bytes ) {
-			@unlink( $this->_tmpfile ); // phpcs:ignore WordPress.PHP.NoSilencedErrors
+			wp_delete_file( $this->_tmpfile );
 			$this->_tmpfile = false;
 			$this->_error   = esc_html__(
 				'The XLSX file exceeds the maximum allowed size and cannot be imported.',
 				'visualizer'
 			);
-			return $this->_filename;
+			return false;
 		}
 
 		return $this->_tmpfile;
@@ -136,8 +131,8 @@ class Visualizer_Source_Xlsx_Remote extends Visualizer_Source_Xlsx {
 		$result = parent::fetch();
 
 		// Clean up the temporary file after parsing.
-		if ( $this->_tmpfile && ! is_wp_error( $this->_tmpfile ) && is_file( $this->_tmpfile ) ) {
-			@unlink( $this->_tmpfile ); // phpcs:ignore WordPress.PHP.NoSilencedErrors
+		if ( $this->_tmpfile && is_file( $this->_tmpfile ) ) {
+			wp_delete_file( $this->_tmpfile );
 			$this->_tmpfile = false;
 		}
 

--- a/tests/e2e/specs/remote-import.spec.js
+++ b/tests/e2e/specs/remote-import.spec.js
@@ -1,0 +1,70 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+/**
+ * Internal dependencies
+ */
+const { deleteAllCharts, getAssetFilePath, CHART_JS_LABELS, selectChartAdmin } = require('../utils/common');
+
+/**
+ * The remote-import UI is Pro-gated, but the admin-ajax endpoint runs in the free
+ * plugin, so these tests drive the endpoint directly (issue #591 SSRF fix).
+ *
+ * On error the endpoint responds with `alert("...")`; on success it assigns
+ * `win.visualizer.charts.canvas.series` / `.data`.
+ */
+test.describe( 'Remote import (secure fetch)', () => {
+    test.beforeEach( async ( { admin, requestUtils, page } ) => {
+        await deleteAllCharts( requestUtils );
+        page.setDefaultTimeout( 5000 );
+    } );
+
+    /**
+     * Opens the classic builder and returns the upload-data admin-ajax URL
+     * (carries the nonce and chart id) from the one-time-import form.
+     */
+    async function getUploadAction( admin, page ) {
+        await admin.visitAdminPage( 'admin.php?page=visualizer&vaction=addnew' );
+        await page.waitForURL( '**/admin.php?page=visualizer&vaction=addnew' );
+        await page.getByRole('button', { name: 'Classic Builder Step-by-step' }).click();
+        await page.waitForSelector('h1:text("Visualizer")');
+
+        await selectChartAdmin( page.frameLocator('iframe'), CHART_JS_LABELS.table );
+
+        return page.frameLocator('iframe').locator('#vz-one-time-import').getAttribute('action');
+    }
+
+    async function importFromUrl( page, action, url ) {
+        const response = await page.request.post( action, {
+            form: {
+                remote_data: url,
+                'vz-import-time': '-1',
+            },
+        } );
+        return response.text();
+    }
+
+    test( 'blocks import from a non-public address', async ( { admin, page } ) => {
+        const action = await getUploadAction( admin, page );
+
+        const body = await importFromUrl( page, action, 'http://169.254.169.254/latest/meta-data/data.csv' );
+
+        expect( body ).toContain( 'alert(' );
+        expect( body ).not.toContain( 'canvas.series' );
+    } );
+
+    test( 'imports a CSV served from the site itself', async ( { admin, page, requestUtils } ) => {
+        const media = await requestUtils.uploadMedia( getAssetFilePath( 'pie.csv' ) );
+        const action = await getUploadAction( admin, page );
+
+        // Inside the wp-env container the mapped port is unreachable; Apache serves the
+        // same site on port 80, so PHP can only fetch the file through that.
+        const containerUrl = media.source_url.replace( /:\d+\//, '/' );
+        const body = await importFromUrl( page, action, containerUrl );
+
+        expect( body ).not.toContain( 'alert(' );
+        expect( body ).toContain( 'canvas.series' );
+    } );
+} );

--- a/tests/test-ajax.php
+++ b/tests/test-ajax.php
@@ -382,6 +382,86 @@ class Test_Visualizer_Ajax extends WP_Ajax_UnitTestCase {
 	}
 
 	/**
+	 * JSON get-data admits a user who can edit the chart (issue #591 access-control fix).
+	 */
+	public function test_json_get_data_allows_editor_for_editable_chart() {
+		$chart_id = $this->factory->post->create(
+			array(
+				'post_type'   => Visualizer_Plugin::CPT_VISUALIZER,
+				'post_author' => $this->admin_user_id,
+			)
+		);
+		$this->_setRole( 'editor' );
+
+		$filter = function () {
+			return array(
+				'headers'  => array(),
+				'body'     => wp_json_encode( array( array( 'name' => 'a', 'value' => 1 ), array( 'name' => 'b', 'value' => 2 ) ) ),
+				'response' => array( 'code' => 200, 'message' => '' ),
+				'cookies'  => array(),
+				'filename' => null,
+			);
+		};
+		add_filter( 'pre_http_request', $filter );
+
+		$_GET['security'] = wp_create_nonce( Visualizer_Plugin::ACTION_JSON_GET_DATA . Visualizer_Plugin::VERSION );
+		$_POST['params']  = array(
+			'url'    => 'http://93.184.216.34/data.json',
+			'method' => 'GET',
+			'chart'  => $chart_id,
+			'root'   => 'root',
+		);
+
+		try {
+			$this->_handleAjax( Visualizer_Plugin::ACTION_JSON_GET_DATA );
+		} catch ( WPAjaxDieContinueException $e ) {
+			// We expected this, do nothing.
+		}
+		remove_filter( 'pre_http_request', $filter );
+
+		$response = json_decode( $this->_last_response );
+		$this->assertIsObject( $response );
+		$this->assertTrue( $response->success );
+	}
+
+	/**
+	 * JSON get-data dies for a chart the user cannot edit (issue #591 access-control fix).
+	 */
+	public function test_json_get_data_denied_for_chart_user_cannot_edit() {
+		$chart_id = $this->factory->post->create(
+			array(
+				'post_type'   => Visualizer_Plugin::CPT_VISUALIZER,
+				'post_author' => $this->admin_user_id,
+			)
+		);
+		$this->_setRole( 'contributor' );
+
+		$requests = 0;
+		$filter   = function ( $preempt ) use ( &$requests ) {
+			$requests++;
+			return $preempt;
+		};
+		add_filter( 'pre_http_request', $filter );
+
+		$_GET['security'] = wp_create_nonce( Visualizer_Plugin::ACTION_JSON_GET_DATA . Visualizer_Plugin::VERSION );
+		$_POST['params']  = array(
+			'url'    => 'http://93.184.216.34/data.json',
+			'method' => 'GET',
+			'chart'  => $chart_id,
+		);
+
+		try {
+			$this->_handleAjax( Visualizer_Plugin::ACTION_JSON_GET_DATA );
+			$this->fail( 'Expected the request to die for a chart the user cannot edit.' );
+		} catch ( WPAjaxDieStopException $e ) {
+			$this->assertSame( '', $e->getMessage() );
+		}
+		remove_filter( 'pre_http_request', $filter );
+
+		$this->assertSame( 0, $requests );
+	}
+
+	/**
 	 * A contributor may use JSON import, but link-local destinations are blocked before transport.
 	 */
 	public function test_json_get_roots_blocks_link_local_for_contributor() {

--- a/tests/test-ajax.php
+++ b/tests/test-ajax.php
@@ -382,39 +382,22 @@ class Test_Visualizer_Ajax extends WP_Ajax_UnitTestCase {
 	}
 
 	/**
-	 * A permitted user (contributor) is not blocked by the guard, and the JSON source fetches through the
-	 * SSRF-safe transport (`reject_unsafe_urls`), matching the CSV path (issue #591 SSRF fix).
+	 * A contributor may use JSON import, but link-local destinations are blocked before transport.
 	 */
-	public function test_json_get_roots_allowed_for_contributor_uses_safe_transport() {
+	public function test_json_get_roots_blocks_link_local_for_contributor() {
 		wp_set_current_user( $this->contibutor_user_id );
 		$this->_setRole( 'contributor' );
 
-		$captured = array();
-		add_filter(
-			'pre_http_request',
-			function ( $pre, $args, $url ) use ( &$captured ) {
-				$captured[] = array(
-					'url'    => $url,
-					'reject' => ! empty( $args['reject_unsafe_urls'] ),
-				);
-				return array(
-					'headers'  => array(),
-					'body'     => wp_json_encode( array( 'results' => array( array( 'id' => 1 ) ) ) ),
-					'response' => array(
-						'code'    => 200,
-						'message' => 'OK',
-					),
-					'cookies'  => array(),
-					'filename' => null,
-				);
-			},
-			10,
-			3
-		);
+		$requests = 0;
+		$filter   = function ( $preempt ) use ( &$requests ) {
+			$requests++;
+			return $preempt;
+		};
+		add_filter( 'pre_http_request', $filter );
 
 		$_GET['security'] = wp_create_nonce( Visualizer_Plugin::ACTION_JSON_GET_ROOTS . Visualizer_Plugin::VERSION );
 		$_POST['params']  = array(
-			'url'    => 'http://127.0.0.1:9999/latest/meta-data/',
+			'url'    => 'http://169.254.169.254/latest/meta-data/',
 			'method' => 'GET',
 		);
 
@@ -423,17 +406,12 @@ class Test_Visualizer_Ajax extends WP_Ajax_UnitTestCase {
 		} catch ( WPAjaxDieContinueException $e ) {
 			// We expected this, do nothing.
 		}
+		remove_filter( 'pre_http_request', $filter );
 
 		$response = json_decode( $this->_last_response );
 		$this->assertIsObject( $response );
-		// The capability guard must NOT block a user who has edit_posts.
-		$msg = isset( $response->data->msg ) ? $response->data->msg : '';
-		$this->assertNotEquals( 'You do not have permission to perform this action.', $msg );
-		// Every outbound request for the JSON source must use the SSRF-safe transport.
-		$this->assertNotEmpty( $captured, 'The JSON source did not attempt any fetch.' );
-		foreach ( $captured as $req ) {
-			$this->assertTrue( $req['reject'], 'JSON fetch must use wp_safe_remote_* (reject_unsafe_urls => true).' );
-		}
+		$this->assertFalse( $response->success );
+		$this->assertSame( 0, $requests );
 	}
 
 	/**

--- a/tests/test-remote-fetch.php
+++ b/tests/test-remote-fetch.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * Tests for safe remote chart imports.
+ *
+ * @package Visualizer
+ */
+
+/**
+ * Test the shared remote fetch policy.
+ */
+class Test_Visualizer_Remote_Fetch extends WP_UnitTestCase {
+
+	/**
+	 * Non-public destinations must be rejected before the HTTP transport runs.
+	 *
+	 * @dataProvider blocked_urls
+	 * @param string $url URL under test.
+	 */
+	public function test_blocks_non_public_destinations_before_request( $url ) {
+		$requests = 0;
+		$filter   = function ( $preempt ) use ( &$requests ) {
+			$requests++;
+			return $preempt;
+		};
+		add_filter( 'pre_http_request', $filter );
+
+		$response = Visualizer_Remote_Fetch::request( $url );
+
+		remove_filter( 'pre_http_request', $filter );
+		$this->assertWPError( $response );
+		$this->assertSame( 0, $requests );
+	}
+
+	/**
+	 * Non-public URL examples.
+	 *
+	 * @return array[]
+	 */
+	public function blocked_urls() {
+		return array(
+			'loopback'       => array( 'http://127.0.0.1/' ),
+			'private'        => array( 'http://10.0.0.1/' ),
+			'link-local'     => array( 'http://169.254.169.254/latest/meta-data/' ),
+			'carrier-grade'  => array( 'http://100.64.0.1/' ),
+			'documentation'  => array( 'http://192.0.2.1/' ),
+			'multicast'      => array( 'http://224.0.0.1/' ),
+		);
+	}
+
+	/**
+	 * A validated public destination reaches the WordPress HTTP transport.
+	 */
+	public function test_allows_public_destination() {
+		$filter = function ( $preempt, $args, $url ) {
+			$this->assertSame( 'http://93.184.216.34/data.json', $url );
+			$this->assertTrue( $args['reject_unsafe_urls'] );
+			return $this->response( 200, array(), '{"ok":true}' );
+		};
+		add_filter( 'pre_http_request', $filter, 10, 3 );
+
+		$response = Visualizer_Remote_Fetch::request( 'http://93.184.216.34/data.json' );
+
+		remove_filter( 'pre_http_request', $filter, 10 );
+		$this->assertNotWPError( $response );
+		$this->assertSame( '{"ok":true}', wp_remote_retrieve_body( $response ) );
+	}
+
+	/**
+	 * Every redirect target must pass the same destination policy.
+	 */
+	public function test_blocks_redirect_to_link_local_destination() {
+		$requests = 0;
+		$filter   = function () use ( &$requests ) {
+			$requests++;
+			return $this->response( 302, array( 'location' => 'http://169.254.169.254/latest/meta-data/' ) );
+		};
+		add_filter( 'pre_http_request', $filter );
+
+		$response = Visualizer_Remote_Fetch::request( 'http://93.184.216.34/start' );
+
+		remove_filter( 'pre_http_request', $filter );
+		$this->assertWPError( $response );
+		$this->assertSame( 'visualizer_unsafe_remote_url', $response->get_error_code() );
+		$this->assertSame( 1, $requests );
+	}
+
+	/**
+	 * Sensitive headers must not follow a redirect to another origin.
+	 */
+	public function test_strips_sensitive_headers_on_cross_origin_redirect() {
+		$requests = array();
+		$filter   = function ( $preempt, $args, $url ) use ( &$requests ) {
+			$requests[] = array( $url, $args['headers'] );
+			if ( 1 === count( $requests ) ) {
+				return $this->response( 302, array( 'location' => 'http://93.184.216.35/data' ) );
+			}
+			return $this->response( 200 );
+		};
+		add_filter( 'pre_http_request', $filter, 10, 3 );
+
+		$response = Visualizer_Remote_Fetch::request(
+			'http://93.184.216.34/start',
+			array(
+				'headers' => array(
+					'Accept'        => 'application/json',
+					'Authorization' => 'Bearer secret',
+					'X-Api-Key'     => 'secret',
+				),
+			)
+		);
+
+		remove_filter( 'pre_http_request', $filter, 10 );
+		$this->assertNotWPError( $response );
+		$this->assertCount( 2, $requests );
+		$this->assertSame( array( 'Accept' => 'application/json' ), $requests[1][1] );
+	}
+
+	/**
+	 * Header and method policy is applied before dispatch.
+	 */
+	public function test_rejects_unsupported_method_before_request() {
+		$requests = 0;
+		$filter   = function ( $preempt ) use ( &$requests ) {
+			$requests++;
+			return $preempt;
+		};
+		add_filter( 'pre_http_request', $filter );
+
+		$response = Visualizer_Remote_Fetch::request( 'http://93.184.216.34/', array( 'method' => 'DELETE' ) );
+
+		remove_filter( 'pre_http_request', $filter );
+		$this->assertWPError( $response );
+		$this->assertSame( 'visualizer_remote_method', $response->get_error_code() );
+		$this->assertSame( 0, $requests );
+	}
+
+	/**
+	 * Builds a WordPress HTTP response fixture.
+	 *
+	 * @param int    $code    Status code.
+	 * @param array  $headers Response headers.
+	 * @param string $body    Response body.
+	 * @return array
+	 */
+	private function response( $code, $headers = array(), $body = '' ) {
+		return array(
+			'headers'  => $headers,
+			'body'     => $body,
+			'response' => array(
+				'code'    => $code,
+				'message' => '',
+			),
+			'cookies'  => array(),
+			'filename' => null,
+		);
+	}
+}

--- a/tests/test-remote-fetch.php
+++ b/tests/test-remote-fetch.php
@@ -164,6 +164,28 @@ class Test_Visualizer_Remote_Fetch extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The pin hook records that the cURL transport dispatched the request.
+	 */
+	public function test_pin_callback_records_execution() {
+		if ( ! function_exists( 'curl_init' ) ) {
+			$this->markTestSkipped( 'cURL is not available.' );
+		}
+
+		$ran    = false;
+		$method = new ReflectionMethod( Visualizer_Remote_Fetch::class, 'pin_validated_addresses' );
+		$method->setAccessible( true );
+		$pin = $method->invokeArgs( null, array( 'http://example.com/data.json', array( '93.184.216.34' ), &$ran ) );
+
+		$this->assertIsCallable( $pin );
+		$this->assertFalse( $ran );
+
+		$pin( curl_init() );
+
+		$this->assertTrue( $ran );
+		remove_action( 'http_api_curl', $pin );
+	}
+
+	/**
 	 * IPv6 addresses use cURL's bracketed CURLOPT_RESOLVE syntax.
 	 */
 	public function test_formats_ipv6_addresses_for_curl_resolve() {

--- a/tests/test-remote-fetch.php
+++ b/tests/test-remote-fetch.php
@@ -164,28 +164,6 @@ class Test_Visualizer_Remote_Fetch extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The pin hook records that the cURL transport dispatched the request.
-	 */
-	public function test_pin_callback_records_execution() {
-		if ( ! function_exists( 'curl_init' ) ) {
-			$this->markTestSkipped( 'cURL is not available.' );
-		}
-
-		$ran    = false;
-		$method = new ReflectionMethod( Visualizer_Remote_Fetch::class, 'pin_validated_addresses' );
-		$method->setAccessible( true );
-		$pin = $method->invokeArgs( null, array( 'http://example.com/data.json', array( '93.184.216.34' ), &$ran ) );
-
-		$this->assertIsCallable( $pin );
-		$this->assertFalse( $ran );
-
-		$pin( curl_init() );
-
-		$this->assertTrue( $ran );
-		remove_action( 'http_api_curl', $pin );
-	}
-
-	/**
 	 * IPv6 addresses use cURL's bracketed CURLOPT_RESOLVE syntax.
 	 */
 	public function test_formats_ipv6_addresses_for_curl_resolve() {

--- a/tests/test-remote-fetch.php
+++ b/tests/test-remote-fetch.php
@@ -119,6 +119,51 @@ class Test_Visualizer_Remote_Fetch extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Cookies must not follow a redirect to another origin.
+	 */
+	public function test_drops_cookies_on_cross_origin_redirect() {
+		$requests = array();
+		$filter   = function ( $preempt, $args, $url ) use ( &$requests ) {
+			$requests[] = array( $url, $args['cookies'] );
+			if ( 1 === count( $requests ) ) {
+				return $this->response( 302, array( 'location' => 'http://93.184.216.35/data' ) );
+			}
+			return $this->response( 200 );
+		};
+		add_filter( 'pre_http_request', $filter, 10, 3 );
+
+		$response = Visualizer_Remote_Fetch::request(
+			'http://93.184.216.34/start',
+			array( 'cookies' => array( 'session' => 'secret' ) )
+		);
+
+		remove_filter( 'pre_http_request', $filter, 10 );
+		$this->assertNotWPError( $response );
+		$this->assertCount( 2, $requests );
+		$this->assertNotEmpty( $requests[0][1] );
+		$this->assertSame( array(), $requests[1][1] );
+	}
+
+	/**
+	 * The validated addresses are pinned on the cURL transport only while the request dispatches.
+	 */
+	public function test_pins_validated_addresses_during_dispatch() {
+		$pinned_during = null;
+		$filter        = function () use ( &$pinned_during ) {
+			$pinned_during = has_action( 'http_api_curl' );
+			return $this->response( 200 );
+		};
+		add_filter( 'pre_http_request', $filter );
+
+		$response = Visualizer_Remote_Fetch::request( 'http://93.184.216.34/data.json' );
+
+		remove_filter( 'pre_http_request', $filter );
+		$this->assertNotWPError( $response );
+		$this->assertTrue( $pinned_during );
+		$this->assertFalse( has_action( 'http_api_curl' ) );
+	}
+
+	/**
 	 * Header and method policy is applied before dispatch.
 	 */
 	public function test_rejects_unsupported_method_before_request() {
@@ -141,7 +186,14 @@ class Test_Visualizer_Remote_Fetch extends WP_UnitTestCase {
 	 * URLs on the site's own host skip the public-address check, matching core.
 	 */
 	public function test_allows_same_host_destination_without_dns_check() {
-		update_option( 'home', 'http://visualizer.internal' );
+		// A filter beats the WP_HOME constant pinned by some test configs (e.g. wp-env), which makes update_option() a no-op.
+		add_filter(
+			'option_home',
+			function () {
+				return 'http://visualizer.internal';
+			},
+			100
+		);
 
 		$requests = 0;
 		$filter   = function ( $preempt ) use ( &$requests ) {
@@ -240,6 +292,28 @@ class Test_Visualizer_Remote_Fetch extends WP_UnitTestCase {
 		remove_filter( 'pre_http_request', $filter, 10 );
 		$this->assertWPError( $response );
 		$this->assertSame( 'visualizer_remote_status', $response->get_error_code() );
+		$this->assertNotEmpty( $tmpfile );
+		$this->assertFileDoesNotExist( $tmpfile );
+	}
+
+	/**
+	 * Downloads are size-capped during transfer and possibly-truncated files are rejected.
+	 */
+	public function test_download_rejects_file_at_size_limit() {
+		$tmpfile = null;
+		$filter  = function ( $preempt, $args ) use ( &$tmpfile ) {
+			$this->assertSame( Visualizer_Remote_Fetch::MAX_DOWNLOAD_BYTES, $args['limit_response_size'] );
+			$tmpfile = $args['filename'];
+			file_put_contents( $tmpfile, str_repeat( 'a', Visualizer_Remote_Fetch::MAX_DOWNLOAD_BYTES ) );
+			return $this->response( 200 );
+		};
+		add_filter( 'pre_http_request', $filter, 10, 2 );
+
+		$response = Visualizer_Remote_Fetch::download( 'http://93.184.216.34/data.csv' );
+
+		remove_filter( 'pre_http_request', $filter, 10 );
+		$this->assertWPError( $response );
+		$this->assertSame( 'visualizer_remote_size', $response->get_error_code() );
 		$this->assertNotEmpty( $tmpfile );
 		$this->assertFileDoesNotExist( $tmpfile );
 	}

--- a/tests/test-remote-fetch.php
+++ b/tests/test-remote-fetch.php
@@ -44,6 +44,7 @@ class Test_Visualizer_Remote_Fetch extends WP_UnitTestCase {
 			'carrier-grade'  => array( 'http://100.64.0.1/' ),
 			'documentation'  => array( 'http://192.0.2.1/' ),
 			'multicast'      => array( 'http://224.0.0.1/' ),
+			'reserved'       => array( 'http://240.0.0.1/' ),
 			'blocked-port'   => array( 'http://93.184.216.34:8443/' ),
 			'ipv4-mapped'    => array( 'http://[::ffff:169.254.169.254]/' ),
 		);

--- a/tests/test-remote-fetch.php
+++ b/tests/test-remote-fetch.php
@@ -44,6 +44,8 @@ class Test_Visualizer_Remote_Fetch extends WP_UnitTestCase {
 			'carrier-grade'  => array( 'http://100.64.0.1/' ),
 			'documentation'  => array( 'http://192.0.2.1/' ),
 			'multicast'      => array( 'http://224.0.0.1/' ),
+			'blocked-port'   => array( 'http://93.184.216.34:8443/' ),
+			'ipv4-mapped'    => array( 'http://[::ffff:169.254.169.254]/' ),
 		);
 	}
 
@@ -54,11 +56,12 @@ class Test_Visualizer_Remote_Fetch extends WP_UnitTestCase {
 		$filter = function ( $preempt, $args, $url ) {
 			$this->assertSame( 'http://93.184.216.34/data.json', $url );
 			$this->assertTrue( $args['reject_unsafe_urls'] );
+			$this->assertSame( Visualizer_Remote_Fetch::MAX_RESPONSE_SIZE, $args['limit_response_size'] );
 			return $this->response( 200, array(), '{"ok":true}' );
 		};
 		add_filter( 'pre_http_request', $filter, 10, 3 );
 
-		$response = Visualizer_Remote_Fetch::request( 'http://93.184.216.34/data.json' );
+		$response = Visualizer_Remote_Fetch::request( 'http://93.184.216.34/data.json', array( 'limit_response_size' => PHP_INT_MAX ) );
 
 		remove_filter( 'pre_http_request', $filter, 10 );
 		$this->assertNotWPError( $response );
@@ -131,6 +134,111 @@ class Test_Visualizer_Remote_Fetch extends WP_UnitTestCase {
 		remove_filter( 'pre_http_request', $filter );
 		$this->assertWPError( $response );
 		$this->assertSame( 'visualizer_remote_method', $response->get_error_code() );
+		$this->assertSame( 0, $requests );
+	}
+
+	/**
+	 * A same-origin redirect (relative Location) keeps request headers and resolves the target URL.
+	 */
+	public function test_same_origin_redirect_keeps_headers_and_resolves_relative_location() {
+		$requests = array();
+		$filter   = function ( $preempt, $args, $url ) use ( &$requests ) {
+			$requests[] = array( $url, $args['headers'] );
+			if ( 1 === count( $requests ) ) {
+				return $this->response( 302, array( 'location' => '/next' ) );
+			}
+			return $this->response( 200 );
+		};
+		add_filter( 'pre_http_request', $filter, 10, 3 );
+
+		$headers  = array(
+			'Accept'        => 'application/json',
+			'Authorization' => 'Bearer secret',
+		);
+		$response = Visualizer_Remote_Fetch::request( 'http://93.184.216.34/start', array( 'headers' => $headers ) );
+
+		remove_filter( 'pre_http_request', $filter, 10 );
+		$this->assertNotWPError( $response );
+		$this->assertCount( 2, $requests );
+		$this->assertSame( 'http://93.184.216.34/next', $requests[1][0] );
+		$this->assertSame( $headers, $requests[1][1] );
+	}
+
+	/**
+	 * The redirect chain must stop after MAX_REDIRECTS hops.
+	 */
+	public function test_stops_after_max_redirects() {
+		$requests = 0;
+		$filter   = function () use ( &$requests ) {
+			$requests++;
+			return $this->response( 302, array( 'location' => 'http://93.184.216.34/hop' . $requests ) );
+		};
+		add_filter( 'pre_http_request', $filter );
+
+		$response = Visualizer_Remote_Fetch::request( 'http://93.184.216.34/start' );
+
+		remove_filter( 'pre_http_request', $filter );
+		$this->assertWPError( $response );
+		$this->assertSame( 'visualizer_too_many_redirects', $response->get_error_code() );
+		$this->assertSame( Visualizer_Remote_Fetch::MAX_REDIRECTS + 1, $requests );
+	}
+
+	/**
+	 * A successful download streams to a temporary file and returns its path.
+	 */
+	public function test_download_returns_temp_file_with_body() {
+		$filter = function ( $preempt, $args ) {
+			$this->assertTrue( $args['stream'] );
+			$this->assertNotEmpty( $args['filename'] );
+			file_put_contents( $args['filename'], 'col1,col2' );
+			return $this->response( 200 );
+		};
+		add_filter( 'pre_http_request', $filter, 10, 2 );
+
+		$tmpfile = Visualizer_Remote_Fetch::download( 'http://93.184.216.34/data.csv' );
+
+		remove_filter( 'pre_http_request', $filter, 10 );
+		$this->assertNotWPError( $tmpfile );
+		$this->assertSame( 'col1,col2', file_get_contents( $tmpfile ) );
+		wp_delete_file( $tmpfile );
+	}
+
+	/**
+	 * A failed download must not leave the temporary file behind.
+	 */
+	public function test_download_removes_temp_file_on_error_status() {
+		$tmpfile = null;
+		$filter  = function ( $preempt, $args ) use ( &$tmpfile ) {
+			$tmpfile = $args['filename'];
+			file_put_contents( $tmpfile, 'not found' );
+			return $this->response( 404 );
+		};
+		add_filter( 'pre_http_request', $filter, 10, 2 );
+
+		$response = Visualizer_Remote_Fetch::download( 'http://93.184.216.34/data.csv' );
+
+		remove_filter( 'pre_http_request', $filter, 10 );
+		$this->assertWPError( $response );
+		$this->assertSame( 'visualizer_remote_status', $response->get_error_code() );
+		$this->assertNotEmpty( $tmpfile );
+		$this->assertFileDoesNotExist( $tmpfile );
+	}
+
+	/**
+	 * Downloads enforce the same destination policy as plain requests.
+	 */
+	public function test_download_blocks_non_public_destination() {
+		$requests = 0;
+		$filter   = function ( $preempt ) use ( &$requests ) {
+			$requests++;
+			return $preempt;
+		};
+		add_filter( 'pre_http_request', $filter );
+
+		$response = Visualizer_Remote_Fetch::download( 'http://169.254.169.254/latest/meta-data/' );
+
+		remove_filter( 'pre_http_request', $filter );
+		$this->assertWPError( $response );
 		$this->assertSame( 0, $requests );
 	}
 

--- a/tests/test-remote-fetch.php
+++ b/tests/test-remote-fetch.php
@@ -155,12 +155,33 @@ class Test_Visualizer_Remote_Fetch extends WP_UnitTestCase {
 		};
 		add_filter( 'pre_http_request', $filter );
 
-		$response = Visualizer_Remote_Fetch::request( 'http://93.184.216.34/data.json' );
+		$response = Visualizer_Remote_Fetch::request( 'http://example.com/data.json' );
 
 		remove_filter( 'pre_http_request', $filter );
 		$this->assertNotWPError( $response );
 		$this->assertTrue( $pinned_during );
 		$this->assertFalse( has_action( 'http_api_curl' ) );
+	}
+
+	/**
+	 * IPv6 addresses use cURL's bracketed CURLOPT_RESOLVE syntax.
+	 */
+	public function test_formats_ipv6_addresses_for_curl_resolve() {
+		$method = new ReflectionMethod( Visualizer_Remote_Fetch::class, 'pin_validated_addresses' );
+		$method->setAccessible( true );
+		$pin = $method->invoke(
+			null,
+			'https://example.com/data.json',
+			array( '93.184.216.34', '2606:2800:220:1:248:1893:25c8:1946' )
+		);
+
+		$this->assertIsCallable( $pin );
+		$reflection = new ReflectionFunction( $pin );
+		$this->assertSame(
+			'example.com:443:93.184.216.34,[2606:2800:220:1:248:1893:25c8:1946]',
+			$reflection->getStaticVariables()['entry']
+		);
+		remove_action( 'http_api_curl', $pin );
 	}
 
 	/**
@@ -299,12 +320,12 @@ class Test_Visualizer_Remote_Fetch extends WP_UnitTestCase {
 	/**
 	 * Downloads are size-capped during transfer and possibly-truncated files are rejected.
 	 */
-	public function test_download_rejects_file_at_size_limit() {
+	public function test_download_rejects_file_over_size_limit() {
 		$tmpfile = null;
 		$filter  = function ( $preempt, $args ) use ( &$tmpfile ) {
-			$this->assertSame( Visualizer_Remote_Fetch::MAX_DOWNLOAD_BYTES, $args['limit_response_size'] );
+			$this->assertSame( Visualizer_Remote_Fetch::MAX_DOWNLOAD_BYTES + 1, $args['limit_response_size'] );
 			$tmpfile = $args['filename'];
-			file_put_contents( $tmpfile, str_repeat( 'a', Visualizer_Remote_Fetch::MAX_DOWNLOAD_BYTES ) );
+			file_put_contents( $tmpfile, str_repeat( 'a', Visualizer_Remote_Fetch::MAX_DOWNLOAD_BYTES + 1 ) );
 			return $this->response( 200 );
 		};
 		add_filter( 'pre_http_request', $filter, 10, 2 );
@@ -316,6 +337,115 @@ class Test_Visualizer_Remote_Fetch extends WP_UnitTestCase {
 		$this->assertSame( 'visualizer_remote_size', $response->get_error_code() );
 		$this->assertNotEmpty( $tmpfile );
 		$this->assertFileDoesNotExist( $tmpfile );
+	}
+
+	/**
+	 * A complete file exactly at the configured limit remains valid.
+	 */
+	public function test_download_accepts_file_at_size_limit() {
+		$filter = function ( $preempt, $args ) {
+			$this->assertSame( 5, $args['limit_response_size'] );
+			file_put_contents( $args['filename'], '1234' );
+			return $this->response( 200 );
+		};
+		add_filter( 'pre_http_request', $filter, 10, 2 );
+
+		$tmpfile = Visualizer_Remote_Fetch::download(
+			'http://93.184.216.34/data.csv',
+			array( 'limit_response_size' => 4 )
+		);
+
+		remove_filter( 'pre_http_request', $filter, 10 );
+		$this->assertNotWPError( $tmpfile );
+		$this->assertSame( '1234', file_get_contents( $tmpfile ) );
+		wp_delete_file( $tmpfile );
+	}
+
+	/**
+	 * Callers may provide a smaller or larger download limit.
+	 */
+	public function test_download_honors_custom_size_limit() {
+		$tmpfile = null;
+		$filter  = function ( $preempt, $args ) use ( &$tmpfile ) {
+			$this->assertSame( 5, $args['limit_response_size'] );
+			$tmpfile = $args['filename'];
+			file_put_contents( $tmpfile, '12345' );
+			return $this->response( 200 );
+		};
+		add_filter( 'pre_http_request', $filter, 10, 2 );
+
+		$response = Visualizer_Remote_Fetch::download(
+			'http://93.184.216.34/data.csv',
+			array( 'limit_response_size' => 4 )
+		);
+
+		remove_filter( 'pre_http_request', $filter, 10 );
+		$this->assertWPError( $response );
+		$this->assertSame( 'visualizer_remote_size', $response->get_error_code() );
+		$this->assertNotEmpty( $tmpfile );
+		$this->assertFileDoesNotExist( $tmpfile );
+	}
+
+	/**
+	 * XLSX probes only need the four-byte ZIP magic number.
+	 *
+	 * @dataProvider xlsx_probe_callbacks
+	 * @param string $class Probe owner.
+	 */
+	public function test_xlsx_probes_limit_response_to_magic_bytes( $class ) {
+		$filter = function ( $preempt, $args ) {
+			$this->assertSame( 4, $args['limit_response_size'] );
+			file_put_contents( $args['filename'], "PK\x03\x04" );
+			return $this->response( 200 );
+		};
+		add_filter( 'pre_http_request', $filter, 10, 2 );
+
+		$method = new ReflectionMethod( $class, '_url_is_xlsx' );
+		$method->setAccessible( true );
+		$result = $method->invoke( null, 'http://93.184.216.34/download' );
+
+		remove_filter( 'pre_http_request', $filter, 10 );
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * XLSX probe owners.
+	 *
+	 * @return array[]
+	 */
+	public function xlsx_probe_callbacks() {
+		return array(
+			'classic'    => array( Visualizer_Module_Chart::class ),
+			'ai builder' => array( Visualizer_Module_AIBuilder::class ),
+		);
+	}
+
+	/**
+	 * The XLSX-specific filter controls the gateway download limit.
+	 */
+	public function test_xlsx_download_uses_filtered_size_limit() {
+		$max_bytes = 12 * 1024 * 1024;
+		$limit     = function () use ( $max_bytes ) {
+			return $max_bytes;
+		};
+		add_filter( 'visualizer_xlsx_max_filesize', $limit );
+
+		$filter = function ( $preempt, $args ) use ( $max_bytes ) {
+			$this->assertSame( $max_bytes + 1, $args['limit_response_size'] );
+			file_put_contents( $args['filename'], 'xlsx' );
+			return $this->response( 200 );
+		};
+		add_filter( 'pre_http_request', $filter, 10, 2 );
+
+		$source = new Visualizer_Source_Xlsx_Remote( 'http://93.184.216.34/data.xlsx' );
+		$method = new ReflectionMethod( $source, '_get_file_path' );
+		$method->setAccessible( true );
+		$path = $method->invoke( $source );
+
+		remove_filter( 'visualizer_xlsx_max_filesize', $limit );
+		remove_filter( 'pre_http_request', $filter, 10 );
+		$this->assertIsString( $path );
+		wp_delete_file( $path );
 	}
 
 	/**

--- a/tests/test-remote-fetch.php
+++ b/tests/test-remote-fetch.php
@@ -57,12 +57,11 @@ class Test_Visualizer_Remote_Fetch extends WP_UnitTestCase {
 		$filter = function ( $preempt, $args, $url ) {
 			$this->assertSame( 'http://93.184.216.34/data.json', $url );
 			$this->assertTrue( $args['reject_unsafe_urls'] );
-			$this->assertSame( Visualizer_Remote_Fetch::MAX_RESPONSE_SIZE, $args['limit_response_size'] );
 			return $this->response( 200, array(), '{"ok":true}' );
 		};
 		add_filter( 'pre_http_request', $filter, 10, 3 );
 
-		$response = Visualizer_Remote_Fetch::request( 'http://93.184.216.34/data.json', array( 'limit_response_size' => PHP_INT_MAX ) );
+		$response = Visualizer_Remote_Fetch::request( 'http://93.184.216.34/data.json' );
 
 		remove_filter( 'pre_http_request', $filter, 10 );
 		$this->assertNotWPError( $response );

--- a/tests/test-remote-fetch.php
+++ b/tests/test-remote-fetch.php
@@ -138,6 +138,26 @@ class Test_Visualizer_Remote_Fetch extends WP_UnitTestCase {
 	}
 
 	/**
+	 * URLs on the site's own host skip the public-address check, matching core.
+	 */
+	public function test_allows_same_host_destination_without_dns_check() {
+		update_option( 'home', 'http://visualizer.internal' );
+
+		$requests = 0;
+		$filter   = function ( $preempt ) use ( &$requests ) {
+			$requests++;
+			return $this->response( 200, array(), 'a,b' );
+		};
+		add_filter( 'pre_http_request', $filter );
+
+		$response = Visualizer_Remote_Fetch::request( 'http://visualizer.internal/wp-content/uploads/data.csv' );
+
+		remove_filter( 'pre_http_request', $filter );
+		$this->assertNotWPError( $response );
+		$this->assertSame( 1, $requests );
+	}
+
+	/**
 	 * A same-origin redirect (relative Location) keeps request headers and resolves the target URL.
 	 */
 	public function test_same_origin_redirect_keeps_headers_and_resolves_relative_location() {


### PR DESCRIPTION
## Summary

Closes the shared SSRF gaps behind Codeinwp/visualizer-pro#591.

- Adds one gateway (`Visualizer_Remote_Fetch`) for user-controlled remote requests and downloads.
- Rejects non-public IPv4/IPv6 destinations (all DNS records checked), including link-local metadata IPs, CGN, multicast, and reserved ranges core misses.
- Re-validates every redirect target, caps redirects, and strips sensitive headers across origins.
- Keeps core's same-host exemption so media library URLs import on hosts that resolve internally.
- Removes CSV URL fopen and unsafe XLSX fallback paths.
- Applies chart-specific authorization to JSON data reads.
- Fixes failed CSV downloads silently importing empty data (surfaced by the new e2e test).
- Adds gateway unit tests, AJAX regression tests, and e2e coverage driving the upload-data endpoint.

## Request workflow

```mermaid
flowchart TD
    A["User-supplied URL<br/>(CSV / XLSX / JSON import)"] --> B{"wp_http_validate_url()"}
    B -- invalid --> X["WP_Error<br/>(no request made)"]
    B -- valid --> C{"Host is the<br/>site's own host?"}
    C -- yes --> R["wp_safe_remote_request()<br/>redirection = 0"]
    C -- no --> D["Resolve ALL A + AAAA records"]
    D -- "no records" --> X
    D --> E{"Every IP public?<br/>(private / loopback / link-local /<br/>CGN / multicast / mapped IPv6)"}
    E -- no --> X
    E -- yes --> R
    R --> G{"3xx with<br/>Location header?"}
    G -- no --> OK["Response<br/>(download(): streamed to temp file,<br/>deleted on non-200)"]
    G -- yes --> H{"Redirect budget left?<br/>(max 5)"}
    H -- no --> X2["WP_Error: too many redirects"]
    H -- yes --> I{"Same origin?"}
    I -- no --> S["Strip Authorization / Cookie /<br/>API-key headers"]
    I -- yes --> B
    S --> B
```

Every redirect hop re-enters the full validation at the top — the classic "validate once, redirect to 169.254.169.254" bypass is closed.
