### PR TITLE
Fix AI Builder local file access

### DIFF
--- a/classes/Visualizer/Module/AIBuilder.php
+++ b/classes/Visualizer/Module/AIBuilder.php
@@ -95,6 +95,17 @@ class Visualizer_Module_AIBuilder extends Visualizer_Module {
 	}
 
 	/**
+	 * Verify that the current user can edit a chart.
+	 *
+	 * @param int $chart_id Chart ID.
+	 */
+	private function _verify_chart_access( $chart_id ): void {
+		if ( ! current_user_can( 'edit_post', $chart_id ) ) {
+			wp_send_json_error( array( 'message' => __( 'Unauthorized.', 'visualizer' ) ), 403 );
+		}
+	}
+
+	/**
 	 * Persist chart data + series from a source.
 	 *
 	 * @param int               $chart_id Chart ID.
@@ -159,6 +170,7 @@ class Visualizer_Module_AIBuilder extends Visualizer_Module {
 		if ( ! $chart_id || ! get_post( $chart_id ) ) {
 			wp_send_json_error( array( 'message' => __( 'Chart not found.', 'visualizer' ) ) );
 		}
+		$this->_verify_chart_access( $chart_id );
 		wp_send_json_success(
 			array(
 				'upload_nonce' => wp_create_nonce( 'visualizer-ai-upload-' . $chart_id ),
@@ -180,6 +192,7 @@ class Visualizer_Module_AIBuilder extends Visualizer_Module {
 		if ( ! $chart || $chart->post_type !== Visualizer_Plugin::CPT_VISUALIZER ) {
 			wp_send_json_error( array( 'message' => __( 'Chart not found.', 'visualizer' ) ) );
 		}
+		$this->_verify_chart_access( $chart_id );
 
 		$series   = get_post_meta( $chart_id, Visualizer_Plugin::CF_SERIES, true );
 		$data     = Visualizer_Module::get_chart_data( $chart, '', false );
@@ -258,6 +271,7 @@ class Visualizer_Module_AIBuilder extends Visualizer_Module {
 		if ( ! get_post( $chart_id ) ) {
 			wp_send_json_error( array( 'message' => __( 'Chart not found.', 'visualizer' ) ) );
 		}
+		$this->_verify_chart_access( $chart_id );
 
 		$source_type = isset( $_POST['source_type'] ) ? sanitize_key( $_POST['source_type'] ) : 'csv_string';
 		$source      = null;
@@ -296,17 +310,6 @@ class Visualizer_Module_AIBuilder extends Visualizer_Module {
 					wp_send_json_error( array( 'message' => __( 'No URL provided.', 'visualizer' ) ) );
 				}
 				$url = wp_unslash( $_POST['file_url'] );
-
-				// Allow local absolute paths in dev (same CSVs used by Classic).
-				if ( is_string( $url ) && file_exists( $url ) && is_readable( $url ) ) {
-					$ext = strtolower( pathinfo( $url, PATHINFO_EXTENSION ) );
-					if ( 'xlsx' === $ext && class_exists( 'Visualizer_Source_Xlsx' ) ) {
-						$source = new Visualizer_Source_Xlsx( $url );
-					} else {
-						$source = new Visualizer_Source_Csv( $url );
-					}
-					break;
-				}
 
 				if ( function_exists( 'wp_http_validate_url' ) ) {
 					$validated_url = wp_http_validate_url( (string) $url );
@@ -435,6 +438,7 @@ class Visualizer_Module_AIBuilder extends Visualizer_Module {
 		if ( ! $chart_id || ! get_post( $chart_id ) ) {
 			wp_send_json_error( array( 'message' => __( 'Chart not found.', 'visualizer' ) ) );
 		}
+		$this->_verify_chart_access( $chart_id );
 
 		$prompt         = isset( $_POST['prompt'] ) ? sanitize_textarea_field( wp_unslash( $_POST['prompt'] ) ) : '';
 		$series         = isset( $_POST['series'] ) ? wp_unslash( $_POST['series'] ) : '';
@@ -560,6 +564,7 @@ class Visualizer_Module_AIBuilder extends Visualizer_Module {
 		if ( ! $chart_id || ! get_post( $chart_id ) ) {
 			wp_send_json_error( array( 'message' => __( 'Chart not found.', 'visualizer' ) ) );
 		}
+		$this->_verify_chart_access( $chart_id );
 		if ( empty( $code ) ) {
 			wp_send_json_error( array( 'message' => __( 'No chart code found. Generate a chart first.', 'visualizer' ) ) );
 		}

--- a/tests/test-ajax.php
+++ b/tests/test-ajax.php
@@ -61,6 +61,102 @@ class Test_Visualizer_Ajax extends WP_Ajax_UnitTestCase {
 	}
 
 	/**
+	 * Test that the AI Builder URL import rejects local file paths.
+	 */
+	public function test_ai_builder_file_url_rejects_local_path() {
+		wp_set_current_user( $this->contibutor_user_id );
+		$chart_id = $this->factory->post->create(
+			array(
+				'post_type'   => Visualizer_Plugin::CPT_VISUALIZER,
+				'post_status' => 'draft',
+				'post_author' => $this->contibutor_user_id,
+			)
+		);
+		$file = wp_tempnam( 'visualizer-local.csv' );
+		file_put_contents( $file, "Label,Value\nstring,number\nSecret,42" );
+
+		$_POST = array(
+			'chart_id'   => $chart_id,
+			'nonce'      => wp_create_nonce( 'visualizer-ai-upload-' . $chart_id ),
+			'source_type' => 'file_url',
+			'file_url'   => $file,
+		);
+
+		try {
+			$this->_handleAjax( 'visualizer-ai-upload' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			// Expected after wp_send_json_error().
+		}
+		wp_delete_file( $file );
+
+		$response = json_decode( $this->_last_response );
+		$this->assertFalse( $response->success );
+		$this->assertSame( 'Invalid URL. Please check the URL and try again.', $response->data->message );
+	}
+
+	/**
+	 * Test that a user cannot request an upload nonce for another user's chart.
+	 */
+	public function test_ai_builder_chart_nonce_requires_chart_edit_permission() {
+		$chart_id = $this->factory->post->create(
+			array(
+				'post_type'   => Visualizer_Plugin::CPT_VISUALIZER,
+				'post_status' => 'publish',
+				'post_author' => $this->admin_user_id,
+			)
+		);
+		wp_set_current_user( $this->contibutor_user_id );
+
+		$_POST = array(
+			'chart_id' => $chart_id,
+			'nonce'    => wp_create_nonce( 'visualizer-ai-builder' ),
+		);
+
+		try {
+			$this->_handleAjax( 'visualizer-ai-chart-nonce' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			// Expected after wp_send_json_error().
+		}
+
+		$response = json_decode( $this->_last_response );
+		$this->assertFalse( $response->success );
+		$this->assertSame( 'Unauthorized.', $response->data->message );
+	}
+
+	/**
+	 * Test that a user cannot upload data to another user's chart.
+	 */
+	public function test_ai_builder_upload_requires_chart_edit_permission() {
+		$chart_id = $this->factory->post->create(
+			array(
+				'post_type'   => Visualizer_Plugin::CPT_VISUALIZER,
+				'post_status' => 'publish',
+				'post_author' => $this->admin_user_id,
+			)
+		);
+		$original_content = get_post_field( 'post_content', $chart_id );
+		wp_set_current_user( $this->contibutor_user_id );
+
+		$_POST = array(
+			'chart_id'   => $chart_id,
+			'nonce'      => wp_create_nonce( 'visualizer-ai-upload-' . $chart_id ),
+			'source_type' => 'csv_string',
+			'csv_data'   => "Label,Value\nstring,number\nSecret,42",
+		);
+
+		try {
+			$this->_handleAjax( 'visualizer-ai-upload' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			// Expected after wp_send_json_error().
+		}
+
+		$response = json_decode( $this->_last_response );
+		$this->assertFalse( $response->success );
+		$this->assertSame( 'Unauthorized.', $response->data->message );
+		$this->assertSame( $original_content, get_post_field( 'post_content', $chart_id ) );
+	}
+
+	/**
 	 * Test the AJAX response for fetching the database data.
 	 */
 	public function test_ajax_response_get_query_data_valid_query() {


### PR DESCRIPTION
## Summary

- remove the development-only local filesystem path handling from AI Builder URL imports
- require edit_post permission for every AI Builder endpoint that accesses an existing chart
- add regression coverage for local path rejection and cross-user chart access

Fixes Codeinwp/visualizer-pro#592