### PR TITLE
test: cover settings sanitization in the chart save flow

### DIFF
--- a/tests/test-ajax.php
+++ b/tests/test-ajax.php
@@ -108,6 +108,7 @@ class Test_Visualizer_Ajax extends WP_Ajax_UnitTestCase {
 		);
 		add_post_meta( $chart_id, Visualizer_Plugin::CF_CHART_TYPE, 'line' );
 
+		$original_request_method   = isset( $_SERVER['REQUEST_METHOD'] ) ? $_SERVER['REQUEST_METHOD'] : null;
 		$_SERVER['REQUEST_METHOD'] = 'POST';
 		$_GET = array(
 			'chart' => $chart_id,
@@ -126,6 +127,12 @@ class Test_Visualizer_Ajax extends WP_Ajax_UnitTestCase {
 			$this->_handleAjax( Visualizer_Plugin::ACTION_EDIT_CHART );
 		} catch ( WPAjaxDieContinueException $e ) {
 			// Expected.
+		} finally {
+			if ( null === $original_request_method ) {
+				unset( $_SERVER['REQUEST_METHOD'] );
+			} else {
+				$_SERVER['REQUEST_METHOD'] = $original_request_method;
+			}
 		}
 
 		$settings = get_post_meta( $chart_id, Visualizer_Plugin::CF_SETTINGS, true );

--- a/tests/test-ajax.php
+++ b/tests/test-ajax.php
@@ -95,6 +95,44 @@ class Test_Visualizer_Ajax extends WP_Ajax_UnitTestCase {
 	}
 
 	/**
+	 * Test that saving chart settings sanitizes the stored settings meta.
+	 */
+	public function test_edit_chart_save_sanitizes_settings_meta() {
+		wp_set_current_user( $this->admin_user_id );
+		$chart_id = $this->factory->post->create(
+			array(
+				'post_type'   => Visualizer_Plugin::CPT_VISUALIZER,
+				'post_status' => 'publish',
+				'post_author' => $this->admin_user_id,
+			)
+		);
+		add_post_meta( $chart_id, Visualizer_Plugin::CF_CHART_TYPE, 'line' );
+
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$_GET = array(
+			'chart' => $chart_id,
+			'tab'   => 'settings',
+			'nonce' => wp_create_nonce(),
+		);
+		// No literal '<' so the payload survives the wp_strip_all_tags() pass at
+		// the top of renderChartPages(); only sanitizeSettings() removes the
+		// percent-encoded octets. This fails if the sanitizeSettings() call is
+		// dropped from the save path.
+		$_POST = array(
+			'backend-title' => 'Chart %3Cscript%3E',
+		);
+
+		try {
+			$this->_handleAjax( Visualizer_Plugin::ACTION_EDIT_CHART );
+		} catch ( WPAjaxDieContinueException $e ) {
+			// Expected.
+		}
+
+		$settings = get_post_meta( $chart_id, Visualizer_Plugin::CF_SETTINGS, true );
+		$this->assertSame( 'Chart script', $settings['backend-title'] );
+	}
+
+	/**
 	 * Test that a user cannot request an upload nonce for another user's chart.
 	 */
 	public function test_ai_builder_chart_nonce_requires_chart_edit_permission() {


### PR DESCRIPTION
Adds a regression test for the XSS fix merged in #1338.

The test saves chart settings through `ACTION_EDIT_CHART` with a percent-encoded `<script>` payload in `backend-title` and asserts the stored `CF_SETTINGS` meta comes back sanitized. The payload avoids a literal `<` so it survives the `wp_strip_all_tags()` pass and fails only if the `sanitizeSettings()` call is dropped from the save path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)