### PR TITLE
fix: enforce chart-level authorization on AJAX handlers (#594)

### DIFF
--- a/classes/Visualizer/Module.php
+++ b/classes/Visualizer/Module.php
@@ -737,7 +737,10 @@ class Visualizer_Module {
 		$chart = get_post( $chart_id );
 		return $chart
 			&& Visualizer_Plugin::CPT_VISUALIZER === $chart->post_type
-			&& current_user_can( 'edit_post', $chart_id );
+			&& (
+				current_user_can( 'edit_post', $chart_id )
+				|| ( (int) $chart->post_author === get_current_user_id() && current_user_can( 'edit_posts' ) )
+			);
 	}
 
 	/**

--- a/classes/Visualizer/Module.php
+++ b/classes/Visualizer/Module.php
@@ -723,6 +723,24 @@ class Visualizer_Module {
 	}
 
 	/**
+	 * Checks whether the current user may edit a specific chart.
+	 *
+	 * @param int $chart_id Chart ID.
+	 * @return bool
+	 */
+	public static function can_edit_chart( $chart_id ) {
+		$chart_id = absint( $chart_id );
+		if ( ! $chart_id ) {
+			return false;
+		}
+
+		$chart = get_post( $chart_id );
+		return $chart
+			&& Visualizer_Plugin::CPT_VISUALIZER === $chart->post_type
+			&& current_user_can( 'edit_post', $chart_id );
+	}
+
+	/**
 	 * Checks if the PRO version is active.
 	 *
 	 * @since 3.3.0

--- a/classes/Visualizer/Module/Admin.php
+++ b/classes/Visualizer/Module/Admin.php
@@ -437,7 +437,7 @@ class Visualizer_Module_Admin extends Visualizer_Module {
 				'filters' => $chart_types,
 				'types'   => array_keys( $chart_types ),
 			),
-			'nonce'      => wp_create_nonce(),
+			'nonce'      => wp_create_nonce( Visualizer_Plugin::ACTION_GET_CHARTS ),
 			'buildurl'   => esc_url( add_query_arg( 'action', Visualizer_Plugin::ACTION_CREATE_CHART, admin_url( 'admin-ajax.php' ) ) ),
 		);
 

--- a/classes/Visualizer/Module/Chart.php
+++ b/classes/Visualizer/Module/Chart.php
@@ -108,19 +108,22 @@ class Visualizer_Module_Chart extends Visualizer_Module {
 	public function setJsonSchedule() {
 		check_ajax_referer( Visualizer_Plugin::ACTION_JSON_SET_SCHEDULE . Visualizer_Plugin::VERSION, 'security' );
 
-		$chart_id = filter_input(
-			INPUT_POST,
-			'chart',
+		$chart_id = isset( $_POST['chart'] ) ? filter_var(
+			$_POST['chart'],
 			FILTER_VALIDATE_INT,
 			array(
 				'options' => array(
 					'min_range' => 1,
 				),
 			)
-		);
+		) : false;
 
 		if ( ! $chart_id ) {
 			wp_send_json_error();
+		}
+
+		if ( ! self::can_edit_chart( $chart_id ) ) {
+			wp_send_json_error( array( 'msg' => esc_html__( 'You do not have permission to perform this action.', 'visualizer' ) ), 403 );
 		}
 
 		$time = filter_input(
@@ -232,10 +235,10 @@ class Visualizer_Module_Chart extends Visualizer_Module {
 		check_ajax_referer( Visualizer_Plugin::ACTION_JSON_SET_DATA . Visualizer_Plugin::VERSION, 'security' );
 
 		$params = $_POST;
-		$chart_id = $_GET['chart'];
+		$chart_id = isset( $_GET['chart'] ) ? absint( $_GET['chart'] ) : 0;
 
-		if ( empty( $chart_id ) ) {
-			wp_die();
+		if ( ! self::can_edit_chart( $chart_id ) ) {
+			wp_die( esc_html__( 'You do not have permission to perform this action.', 'visualizer' ), '', array( 'response' => 403 ) );
 		}
 
 		$chart  = get_post( $chart_id );
@@ -319,6 +322,12 @@ class Visualizer_Module_Chart extends Visualizer_Module {
 	 * @access public
 	 */
 	public function getCharts() {
+		check_ajax_referer( Visualizer_Plugin::ACTION_GET_CHARTS, 'nonce' );
+
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			wp_send_json_error( array( 'msg' => esc_html__( 'You do not have permission to perform this action.', 'visualizer' ) ), 403 );
+		}
+
 		$query_args = array(
 			'post_type'      => Visualizer_Plugin::CPT_VISUALIZER,
 			'posts_per_page' => 9,
@@ -334,6 +343,9 @@ class Visualizer_Module_Chart extends Visualizer_Module {
 				)
 			),
 		);
+		if ( ! current_user_can( 'edit_others_posts' ) ) {
+			$query_args['author'] = get_current_user_id();
+		}
 		$filter     = filter_input( INPUT_GET, 's', FILTER_SANITIZE_STRING );
 		if ( empty( $filter ) ) {
 			// 'filter' is from the modal from the add media button.
@@ -454,24 +466,24 @@ class Visualizer_Module_Chart extends Visualizer_Module {
 	 */
 	public function deleteChart() {
 		$is_post      = $_SERVER['REQUEST_METHOD'] === 'POST';
-		$input_method = $is_post ? INPUT_POST : INPUT_GET;
+		$input        = $is_post ? $_POST : $_GET;
 		$chart_id     = $success = false;
-		$nonce        = wp_verify_nonce( filter_input( $input_method, 'nonce' ) );
-		$capable      = current_user_can( 'delete_posts' );
-		if ( $nonce && $capable ) {
-			$chart_id = filter_input(
-				$input_method,
-				'chart',
+		$nonce        = isset( $input['nonce'] ) && wp_verify_nonce( $input['nonce'] );
+		if ( $nonce ) {
+			$chart_id = isset( $input['chart'] ) ? filter_var(
+				$input['chart'],
 				FILTER_VALIDATE_INT,
 				array(
 					'options' => array(
 						'min_range' => 1,
 					),
 				)
-			);
+			) : false;
 			if ( $chart_id ) {
 				$chart   = get_post( $chart_id );
-				$success = $chart && $chart->post_type === Visualizer_Plugin::CPT_VISUALIZER;
+				$success = $chart
+					&& $chart->post_type === Visualizer_Plugin::CPT_VISUALIZER
+					&& current_user_can( 'delete_post', $chart_id );
 			}
 		}
 		if ( $success ) {
@@ -554,6 +566,9 @@ class Visualizer_Module_Chart extends Visualizer_Module {
 			$_POST = map_deep( $_POST, 'wp_strip_all_tags' );
 		}
 		$chart = $chart_id ? get_post( $chart_id ) : null;
+		if ( $chart && ! self::can_edit_chart( $chart_id ) ) {
+			wp_die( esc_html__( 'You do not have permission to access this page.', 'visualizer' ), '', array( 'response' => 403 ) );
+		}
 		if ( ! $chart_id || ! $chart || $chart->post_type !== Visualizer_Plugin::CPT_VISUALIZER ) {
 			if ( empty( $_GET['lang'] ) || empty( $_GET['parent_chart_id'] ) ) {
 				$this->deleteOldCharts();
@@ -592,7 +607,7 @@ class Visualizer_Module_Chart extends Visualizer_Module {
 			} else {
 				$parent_chart_id = filter_var( $_GET['parent_chart_id'], FILTER_VALIDATE_INT );
 				$success = false;
-				if ( $parent_chart_id ) {
+				if ( $parent_chart_id && self::can_edit_chart( $parent_chart_id ) ) {
 					$parent_chart   = get_post( $parent_chart_id );
 					$success = $parent_chart && $parent_chart->post_type === Visualizer_Plugin::CPT_VISUALIZER;
 				}
@@ -800,13 +815,13 @@ class Visualizer_Module_Chart extends Visualizer_Module {
 	 * Handle data and settings page
 	 */
 	private function _handleDataAndSettingsPage() {
-		if ( isset( $_POST['map_api_key'] ) ) {
-			update_option( 'visualizer-map-api-key', $_POST['map_api_key'] );
-		}
-
 		if ( $_SERVER['REQUEST_METHOD'] === 'POST' && isset( $_GET['nonce'] ) && wp_verify_nonce( $_GET['nonce'] ) ) {
 			$is_canceled      = isset( $_POST['cancel'] ) && 1 === intval( $_POST['cancel'] );
 			$is_newly_created = $this->_chart->post_status === 'auto-draft';
+
+			if ( isset( $_POST['map_api_key'] ) && current_user_can( 'manage_options' ) ) {
+				update_option( 'visualizer-map-api-key', sanitize_text_field( wp_unslash( $_POST['map_api_key'] ) ) );
+			}
 
 			if ( $is_newly_created && ! $is_canceled ) {
 				$this->_chart->post_status = 'publish';
@@ -1431,10 +1446,9 @@ class Visualizer_Module_Chart extends Visualizer_Module {
 	public function cloneChart() {
 		$chart_id = $success = false;
 		$nonce    = isset( $_GET['nonce'] ) && wp_verify_nonce( $_GET['nonce'], Visualizer_Plugin::ACTION_CLONE_CHART );
-		$capable  = current_user_can( 'edit_posts' );
-		if ( $nonce && $capable ) {
+		if ( $nonce ) {
 			$chart_id = isset( $_GET['chart'] ) ? filter_var( $_GET['chart'], FILTER_VALIDATE_INT ) : '';
-			if ( $chart_id ) {
+			if ( $chart_id && self::can_edit_chart( $chart_id ) ) {
 				$chart   = get_post( $chart_id );
 				$success = $chart && $chart->post_type === Visualizer_Plugin::CPT_VISUALIZER;
 			}
@@ -1490,22 +1504,19 @@ class Visualizer_Module_Chart extends Visualizer_Module {
 	 */
 	public function exportData() {
 		check_ajax_referer( Visualizer_Plugin::ACTION_EXPORT_DATA . Visualizer_Plugin::VERSION, 'security' );
-		$capable  = current_user_can( 'edit_posts' );
-		if ( $capable ) {
-			$chart_id = isset( $_GET['chart'] ) ? filter_var(
-				$_GET['chart'],
-				FILTER_VALIDATE_INT,
-				array(
-					'options' => array(
-						'min_range' => 1,
-					),
-				)
-			) : '';
-			if ( $chart_id ) {
-				$data   = $this->_getDataAs( $chart_id, 'csv' );
-				if ( $data ) {
-					echo wp_send_json_success( $data );
-				}
+		$chart_id = isset( $_GET['chart'] ) ? filter_var(
+			$_GET['chart'],
+			FILTER_VALIDATE_INT,
+			array(
+				'options' => array(
+					'min_range' => 1,
+				),
+			)
+		) : '';
+		if ( $chart_id && self::can_edit_chart( $chart_id ) ) {
+			$data   = $this->_getDataAs( $chart_id, 'csv' );
+			if ( $data ) {
+				echo wp_send_json_success( $data );
 			}
 		}
 
@@ -1687,16 +1698,19 @@ class Visualizer_Module_Chart extends Visualizer_Module {
 	public function saveFilter() {
 		check_ajax_referer( Visualizer_Plugin::ACTION_SAVE_FILTER_QUERY . Visualizer_Plugin::VERSION, 'security' );
 
-		$chart_id   = filter_input(
-			INPUT_GET,
-			'chart',
+		$chart_id = isset( $_GET['chart'] ) ? filter_var(
+			$_GET['chart'],
 			FILTER_VALIDATE_INT,
 			array(
 				'options' => array(
 					'min_range' => 1,
 				),
 			)
-		);
+		) : false;
+
+		if ( ! self::can_edit_chart( $chart_id ) ) {
+			wp_send_json_error( array( 'msg' => esc_html__( 'You do not have permission to perform this action.', 'visualizer' ) ), 403 );
+		}
 
 		$hours = filter_input(
 			INPUT_POST,

--- a/classes/Visualizer/Module/Chart.php
+++ b/classes/Visualizer/Module/Chart.php
@@ -483,7 +483,10 @@ class Visualizer_Module_Chart extends Visualizer_Module {
 				$chart   = get_post( $chart_id );
 				$success = $chart
 					&& $chart->post_type === Visualizer_Plugin::CPT_VISUALIZER
-					&& current_user_can( 'delete_post', $chart_id );
+					&& (
+						current_user_can( 'delete_post', $chart_id )
+						|| ( (int) $chart->post_author === get_current_user_id() && current_user_can( 'delete_posts' ) )
+					);
 			}
 		}
 		if ( $success ) {

--- a/js/media/collection.js
+++ b/js/media/collection.js
@@ -7,7 +7,8 @@
 				options = options || {};
 				options.type = 'GET';
 				options.data = _.extend( options.data || {}, {
-					action:  wp.media.view.l10n.visualizer.actions.get_charts
+					action: wp.media.view.l10n.visualizer.actions.get_charts,
+					nonce: wp.media.view.l10n.visualizer.nonce
 				});
 
 				return wp.media.ajax( options );

--- a/tests/test-ajax.php
+++ b/tests/test-ajax.php
@@ -636,6 +636,223 @@ class Test_Visualizer_Ajax extends WP_Ajax_UnitTestCase {
 	}
 
 	/**
+	 * Chart authorization validates both the object type and meta capability.
+	 */
+	public function test_chart_authorization_is_object_specific() {
+		$own_chart   = $this->create_chart_for_user( $this->contibutor_user_id );
+		$other_chart = $this->create_chart_for_user( $this->admin_user_id );
+		$regular_post = $this->factory->post->create(
+			array(
+				'post_author' => $this->contibutor_user_id,
+			)
+		);
+		wp_set_current_user( $this->contibutor_user_id );
+
+		$this->assertTrue( Visualizer_Module::can_edit_chart( $own_chart ) );
+		$this->assertFalse( Visualizer_Module::can_edit_chart( $other_chart ) );
+		$this->assertFalse( Visualizer_Module::can_edit_chart( $regular_post ) );
+		$this->assertFalse( Visualizer_Module::can_edit_chart( PHP_INT_MAX ) );
+	}
+
+	/**
+	 * The chart editor rejects another user's chart before saving settings.
+	 */
+	public function test_edit_chart_denied_for_chart_user_cannot_edit() {
+		$chart_id = $this->create_chart_for_user( $this->admin_user_id );
+		$original = array( 'title' => 'Original' );
+		update_post_meta( $chart_id, Visualizer_Plugin::CF_SETTINGS, $original );
+		wp_set_current_user( $this->contibutor_user_id );
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$_GET = array(
+			'chart' => $chart_id,
+			'tab'   => 'settings',
+			'nonce' => wp_create_nonce(),
+		);
+		$_POST = array(
+			'title' => 'Overwritten',
+			'save'  => 1,
+		);
+
+		try {
+			$this->_handleAjax( Visualizer_Plugin::ACTION_EDIT_CHART );
+			$this->fail( 'Expected the request to die for a chart the user cannot edit.' );
+		} catch ( WPAjaxDieStopException $e ) {
+			$this->assertStringContainsString( 'permission', $e->getMessage() );
+		}
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+
+		$this->assertSame( $original, get_post_meta( $chart_id, Visualizer_Plugin::CF_SETTINGS, true ) );
+	}
+
+	/**
+	 * Chart editors cannot update the site-wide map API key.
+	 */
+	public function test_edit_chart_map_api_key_requires_manage_options() {
+		$chart_id = $this->create_chart_for_user( $this->contibutor_user_id );
+		add_post_meta( $chart_id, Visualizer_Plugin::CF_CHART_TYPE, 'line' );
+		update_option( 'visualizer-map-api-key', 'original-key' );
+		wp_set_current_user( $this->contibutor_user_id );
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$_GET = array(
+			'chart' => $chart_id,
+			'tab'   => 'settings',
+			'nonce' => wp_create_nonce(),
+		);
+		$_POST = array(
+			'map_api_key' => 'attacker-key',
+			'save'        => 1,
+		);
+
+		try {
+			$this->_handleAjax( Visualizer_Plugin::ACTION_EDIT_CHART );
+		} catch ( WPAjaxDieContinueException $e ) {
+			// Expected when the editor response completes.
+		}
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+
+		$this->assertSame( 'original-key', get_option( 'visualizer-map-api-key' ) );
+	}
+
+	/**
+	 * Contributors only receive charts they own from the library endpoint.
+	 */
+	public function test_get_charts_only_lists_editable_scope_for_contributor() {
+		$own_chart   = $this->create_chart_for_user( $this->contibutor_user_id, 'publish' );
+		$other_chart = $this->create_chart_for_user( $this->admin_user_id, 'publish' );
+		wp_set_current_user( $this->contibutor_user_id );
+		$_GET = array(
+			'nonce' => wp_create_nonce( Visualizer_Plugin::ACTION_GET_CHARTS ),
+		);
+
+		try {
+			$this->_handleAjax( Visualizer_Plugin::ACTION_GET_CHARTS );
+		} catch ( WPAjaxDieContinueException $e ) {
+			// Expected after the JSON response.
+		}
+
+		$response  = json_decode( $this->_last_response, true );
+		$chart_ids = wp_list_pluck( $response['data'], 'id' );
+		$this->assertTrue( $response['success'] );
+		$this->assertContains( $own_chart, $chart_ids );
+		$this->assertNotContains( $other_chart, $chart_ids );
+	}
+
+	/**
+	 * A valid nonce does not permit deleting another user's chart.
+	 */
+	public function test_delete_chart_denied_for_chart_user_cannot_delete() {
+		$chart_id = $this->create_chart_for_user( $this->admin_user_id );
+		wp_set_current_user( $this->contibutor_user_id );
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$_POST = array(
+			'chart' => $chart_id,
+			'nonce' => wp_create_nonce(),
+		);
+
+		try {
+			$this->_handleAjax( Visualizer_Plugin::ACTION_DELETE_CHART );
+		} catch ( WPAjaxDieContinueException $e ) {
+			// Expected after the JSON response.
+		}
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+
+		$response = json_decode( $this->_last_response );
+		$this->assertFalse( $response->success );
+		$this->assertNotNull( get_post( $chart_id ) );
+	}
+
+	/**
+	 * A valid nonce does not permit cloning another user's chart.
+	 */
+	public function test_clone_chart_denied_for_chart_user_cannot_edit() {
+		$chart_id = $this->create_chart_for_user( $this->admin_user_id );
+		wp_set_current_user( $this->contibutor_user_id );
+		$_GET = array(
+			'chart' => $chart_id,
+			'nonce' => wp_create_nonce( Visualizer_Plugin::ACTION_CLONE_CHART ),
+		);
+		$before = wp_count_posts( Visualizer_Plugin::CPT_VISUALIZER )->draft;
+
+		try {
+			$this->_handleAjax( Visualizer_Plugin::ACTION_CLONE_CHART );
+		} catch ( WPAjaxDieContinueException $e ) {
+			// Expected when the handler ends.
+		}
+
+		$this->assertSame( $before, wp_count_posts( Visualizer_Plugin::CPT_VISUALIZER )->draft );
+	}
+
+	/**
+	 * A user cannot alter another user's JSON refresh schedule.
+	 */
+	public function test_json_schedule_denied_for_chart_user_cannot_edit() {
+		$chart_id = $this->create_chart_for_user( $this->admin_user_id );
+		wp_set_current_user( $this->contibutor_user_id );
+		$_POST = array(
+			'chart'    => $chart_id,
+			'time'     => 12,
+			'security' => wp_create_nonce( Visualizer_Plugin::ACTION_JSON_SET_SCHEDULE . Visualizer_Plugin::VERSION ),
+		);
+
+		try {
+			$this->_handleAjax( Visualizer_Plugin::ACTION_JSON_SET_SCHEDULE );
+		} catch ( WPAjaxDieContinueException $e ) {
+			// Expected after the JSON response.
+		}
+
+		$response = json_decode( $this->_last_response );
+		$this->assertFalse( $response->success );
+		$this->assertSame( '', get_post_meta( $chart_id, Visualizer_Plugin::CF_JSON_SCHEDULE, true ) );
+	}
+
+	/**
+	 * A user cannot replace another user's JSON chart data.
+	 */
+	public function test_json_set_data_denied_for_chart_user_cannot_edit() {
+		$chart_id = $this->create_chart_for_user( $this->admin_user_id );
+		wp_set_current_user( $this->contibutor_user_id );
+		$_GET = array(
+			'chart'    => $chart_id,
+			'security' => wp_create_nonce( Visualizer_Plugin::ACTION_JSON_SET_DATA . Visualizer_Plugin::VERSION ),
+		);
+		$_POST = array(
+			'url'    => 'https://example.com/data.json',
+			'method' => 'GET',
+			'root'   => 'items',
+		);
+
+		try {
+			$this->_handleAjax( Visualizer_Plugin::ACTION_JSON_SET_DATA );
+			$this->fail( 'Expected the request to die for a chart the user cannot edit.' );
+		} catch ( WPAjaxDieStopException $e ) {
+			$this->assertStringContainsString( 'permission', $e->getMessage() );
+		}
+
+		$this->assertSame( '', get_post_meta( $chart_id, Visualizer_Plugin::CF_JSON_URL, true ) );
+	}
+
+	/**
+	 * A user cannot save filters on another user's chart.
+	 */
+	public function test_save_filter_denied_for_chart_user_cannot_edit() {
+		$chart_id = $this->create_chart_for_user( $this->admin_user_id );
+		wp_set_current_user( $this->contibutor_user_id );
+		$_GET = array(
+			'chart'    => $chart_id,
+			'security' => wp_create_nonce( Visualizer_Plugin::ACTION_SAVE_FILTER_QUERY . Visualizer_Plugin::VERSION ),
+		);
+
+		try {
+			$this->_handleAjax( Visualizer_Plugin::ACTION_SAVE_FILTER_QUERY );
+		} catch ( WPAjaxDieContinueException $e ) {
+			// Expected after the JSON response.
+		}
+
+		$response = json_decode( $this->_last_response );
+		$this->assertFalse( $response->success );
+	}
+
+	/**
 	 * Test that the setup wizard import step builds per-row settings from the
 	 * decoded sample data, covering the decode_content() call in the wizard.
 	 */
@@ -665,6 +882,24 @@ class Test_Visualizer_Ajax extends WP_Ajax_UnitTestCase {
 		$this->assertGreaterThan( 0, $expected_rows );
 		$this->assertCount( $expected_rows, $settings['series'] );
 		$this->assertCount( $expected_rows, $settings['slices'] );
+	}
+
+	/**
+	 * Creates a chart owned by a specific user.
+	 *
+	 * @param int    $user_id User ID.
+	 * @param string $status Post status.
+	 * @return int
+	 */
+	private function create_chart_for_user( $user_id, $status = 'draft' ) {
+		return $this->factory->post->create(
+			array(
+				'post_type'    => Visualizer_Plugin::CPT_VISUALIZER,
+				'post_status'  => $status,
+				'post_author'  => $user_id,
+				'post_content' => wp_json_encode( array( 'data' => array(), 'metadata' => array() ) ),
+			)
+		);
 	}
 
 	/**

--- a/tests/test-ajax.php
+++ b/tests/test-ajax.php
@@ -639,7 +639,7 @@ class Test_Visualizer_Ajax extends WP_Ajax_UnitTestCase {
 	 * Chart authorization validates both the object type and meta capability.
 	 */
 	public function test_chart_authorization_is_object_specific() {
-		$own_chart   = $this->create_chart_for_user( $this->contibutor_user_id );
+		$own_chart   = $this->create_chart_for_user( $this->contibutor_user_id, 'publish' );
 		$other_chart = $this->create_chart_for_user( $this->admin_user_id );
 		$regular_post = $this->factory->post->create(
 			array(
@@ -759,6 +759,30 @@ class Test_Visualizer_Ajax extends WP_Ajax_UnitTestCase {
 		$response = json_decode( $this->_last_response );
 		$this->assertFalse( $response->success );
 		$this->assertNotNull( get_post( $chart_id ) );
+	}
+
+	/**
+	 * A contributor may delete their own published chart.
+	 */
+	public function test_delete_chart_allows_owner_without_delete_published_posts() {
+		$chart_id = $this->create_chart_for_user( $this->contibutor_user_id, 'publish' );
+		wp_set_current_user( $this->contibutor_user_id );
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$_POST = array(
+			'chart' => $chart_id,
+			'nonce' => wp_create_nonce(),
+		);
+
+		try {
+			$this->_handleAjax( Visualizer_Plugin::ACTION_DELETE_CHART );
+		} catch ( WPAjaxDieContinueException $e ) {
+			// Expected after the JSON response.
+		}
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+
+		$response = json_decode( $this->_last_response );
+		$this->assertTrue( $response->success );
+		$this->assertNull( get_post( $chart_id ) );
 	}
 
 	/**

--- a/tests/test-ajax.php
+++ b/tests/test-ajax.php
@@ -775,8 +775,11 @@ class Test_Visualizer_Ajax extends WP_Ajax_UnitTestCase {
 
 		try {
 			$this->_handleAjax( Visualizer_Plugin::ACTION_CLONE_CHART );
+			$this->fail( 'Expected the request to die for a chart the user cannot edit.' );
+		} catch ( WPAjaxDieStopException $e ) {
+			// cloneChart() ends with wp_die() in the test environment when denied.
 		} catch ( WPAjaxDieContinueException $e ) {
-			// Expected when the handler ends.
+			// Expected when the handler ends normally.
 		}
 
 		$this->assertSame( $before, wp_count_posts( Visualizer_Plugin::CPT_VISUALIZER )->draft );

--- a/tests/test-ajax.php
+++ b/tests/test-ajax.php
@@ -892,14 +892,27 @@ class Test_Visualizer_Ajax extends WP_Ajax_UnitTestCase {
 	 * @return int
 	 */
 	private function create_chart_for_user( $user_id, $status = 'draft' ) {
-		return $this->factory->post->create(
+		$chart_id = $this->factory->post->create(
 			array(
 				'post_type'    => Visualizer_Plugin::CPT_VISUALIZER,
 				'post_status'  => $status,
 				'post_author'  => $user_id,
-				'post_content' => wp_json_encode( array( 'data' => array(), 'metadata' => array() ) ),
+				'post_content' => wp_slash( serialize( array( array( 'Label' ), array( 'Value' ) ) ) ),
 			)
 		);
+		add_post_meta( $chart_id, Visualizer_Plugin::CF_CHART_TYPE, 'line' );
+		add_post_meta(
+			$chart_id,
+			Visualizer_Plugin::CF_SERIES,
+			array(
+				array(
+					'label' => 'Label',
+					'type'  => 'string',
+				),
+			)
+		);
+
+		return $chart_id;
 	}
 
 	/**

--- a/tests/test-export.php
+++ b/tests/test-export.php
@@ -163,4 +163,21 @@ class Test_Export extends WP_Ajax_UnitTestCase {
 		$response = json_decode( $this->_last_response );
 		$this->assertTrue( empty( $response ) || empty( $response->success ) );
 	}
+
+	/**
+	 * Exporting requires permission to edit the requested chart.
+	 */
+	public function test_csv_export_denied_for_chart_user_cannot_edit() {
+		$this->create_chart();
+		$user_id = $this->factory->user->create(
+			array(
+				'role' => 'contributor',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		$response = $this->run_export();
+
+		$this->assertTrue( empty( $response ) || empty( $response->success ) );
+	}
 }


### PR DESCRIPTION
## Summary
- Add \Visualizer_Module::can_edit_chart()\ and use it across the remaining free AJAX handlers affected by #594.
- Require nonce plus capability for \getCharts\, enforce per-chart checks on delete/clone/export/JSON/filter/edit flows, and scope library listings to editable charts.
- Add regression tests covering unauthorized chart access, map API key updates, and export denial.

## Related
- Companion PR: https://github.com/Codeinwp/visualizer-pro/pull/601
- Closes Codeinwp/visualizer-pro#594 (free half)

## Test plan
- [ ] Run PHPUnit in CI for \	ests/test-ajax.php\ and \	ests/test-export.php\
- [ ] Verify a contributor cannot delete, clone, export, or edit another user's chart
- [ ] Verify \isualizer-get-charts\ requires nonce + \edit_posts\ and only returns editable charts
- [ ] Verify JSON schedule/data/filter handlers reject foreign chart IDs