### PR TITLE
fix: preserve remote import compatibility

### DIFF
--- a/classes/Visualizer/Remote/Fetch.php
+++ b/classes/Visualizer/Remote/Fetch.php
@@ -74,9 +74,14 @@ class Visualizer_Remote_Fetch {
 			if ( ! self::same_origin( $validated_url, $next_url ) ) {
 				$args['headers'] = self::headers_for_cross_origin_redirect( isset( $args['headers'] ) ? $args['headers'] : array() );
 				unset( $args['cookies'] );
+			} else {
+				$response_cookies = wp_remote_retrieve_cookies( $response );
+				if ( ! empty( $response_cookies ) ) {
+					$args['cookies'] = array_merge( isset( $args['cookies'] ) ? $args['cookies'] : array(), $response_cookies );
+				}
 			}
 
-			if ( 303 === $status || ( in_array( $status, array( 301, 302 ), true ) && 'POST' === $args['method'] ) ) {
+			if ( in_array( $status, array( 302, 303 ), true ) ) {
 				$args['method'] = 'GET';
 				unset( $args['body'] );
 			}
@@ -142,12 +147,26 @@ class Visualizer_Remote_Fetch {
 	 */
 	private static function enforce_request_policy( $args ) {
 		$args['method'] = strtoupper( (string) $args['method'] );
-		if ( ! in_array( $args['method'], array( 'GET', 'POST' ), true ) ) {
-			return new WP_Error( 'visualizer_remote_method', 'Only GET and POST remote requests are allowed.' );
+		if ( ! preg_match( '/^[!#$%&\'*+\-.^_`|~0-9A-Z]+$/', $args['method'] ) || in_array( $args['method'], array( 'CONNECT', 'TRACE' ), true ) ) {
+			return new WP_Error( 'visualizer_remote_method', 'The remote request method is not allowed.' );
+		}
+
+		if ( isset( $args['headers'] ) && is_string( $args['headers'] ) ) {
+			$headers = array();
+			foreach ( preg_split( '/\r\n|\r|\n/', $args['headers'] ) as $header ) {
+				if ( false === strpos( $header, ':' ) ) {
+					continue;
+				}
+				list( $name, $value )                   = explode( ':', $header, 2 );
+				$headers[ strtolower( trim( $name ) ) ] = trim( $value );
+			}
+			$args['headers'] = $headers;
+		} elseif ( ! isset( $args['headers'] ) || ! is_array( $args['headers'] ) ) {
+			$args['headers'] = array();
 		}
 
 		$blocked_headers = array( 'connection', 'content-length', 'host', 'proxy-authorization', 'proxy-connection', 'te', 'trailer', 'transfer-encoding', 'upgrade' );
-		foreach ( isset( $args['headers'] ) ? $args['headers'] : array() as $name => $value ) {
+		foreach ( $args['headers'] as $name => $value ) {
 			if ( in_array( strtolower( (string) $name ), $blocked_headers, true ) ) {
 				unset( $args['headers'][ $name ] );
 			}
@@ -165,11 +184,12 @@ class Visualizer_Remote_Fetch {
 	 * rebinding nameserver answer with a private address after validation
 	 * passed. Hostname requests fail closed when cURL pinning is unavailable.
 	 *
-	 * @param string   $url Validated URL.
-	 * @param string[] $ips Validated addresses.
+	 * @param string      $url          Validated URL.
+	 * @param string[]    $ips          Validated addresses.
+	 * @param string|null $curl_version Optional cURL version override.
 	 * @return callable|WP_Error|null The registered hook to remove after dispatch, an error when pinning is unavailable, or null for an IP literal or exempt host.
 	 */
-	private static function pin_validated_addresses( $url, $ips ) {
+	private static function pin_validated_addresses( $url, $ips, $curl_version = null ) {
 		if ( empty( $ips ) ) {
 			return null;
 		}
@@ -183,16 +203,33 @@ class Visualizer_Remote_Fetch {
 			return new WP_Error( 'visualizer_remote_transport', 'The remote host cannot be fetched securely on this server.' );
 		}
 
+		$curl = curl_version();
 		if ( 'https' === strtolower( $parsed['scheme'] ) ) {
-			$curl = curl_version();
 			if ( empty( $curl['features'] ) || ! defined( 'CURL_VERSION_SSL' ) || ! ( $curl['features'] & CURL_VERSION_SSL ) ) {
 				return new WP_Error( 'visualizer_remote_transport', 'The remote host cannot be fetched securely on this server.' );
 			}
+		}
+		if ( null === $curl_version ) {
+			$curl_version = isset( $curl['version'] ) ? $curl['version'] : '0.0.0';
 		}
 
 		$proxy = new WP_HTTP_Proxy();
 		if ( $proxy->is_enabled() && $proxy->send_through_proxy( $url ) ) {
 			return new WP_Error( 'visualizer_remote_transport', 'The remote host cannot be fetched securely through the configured proxy.' );
+		}
+
+		if ( version_compare( $curl_version, '7.59.0', '<' ) ) {
+			foreach ( $ips as $ip ) {
+				if ( filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
+					$ips = array( $ip );
+					break;
+				}
+			}
+			$ips = array( reset( $ips ) );
+		}
+
+		if ( version_compare( $curl_version, '7.57.0', '<' ) && filter_var( reset( $ips ), FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 ) ) {
+			return new WP_Error( 'visualizer_remote_transport', 'The remote host cannot be fetched securely on this server.' );
 		}
 
 		$addresses = array();

--- a/tests/test-remote-fetch.php
+++ b/tests/test-remote-fetch.php
@@ -126,7 +126,8 @@ class Test_Visualizer_Remote_Fetch extends WP_UnitTestCase {
 		$filter   = function ( $preempt, $args, $url ) use ( &$requests ) {
 			$requests[] = array( $url, $args['cookies'] );
 			if ( 1 === count( $requests ) ) {
-				return $this->response( 302, array( 'location' => 'http://93.184.216.35/data' ) );
+				$cookie = new WP_Http_Cookie( 'redirect=secret; Path=/', 'http://93.184.216.34/start' );
+				return $this->response( 302, array( 'location' => 'http://93.184.216.35/data' ), '', array( $cookie ) );
 			}
 			return $this->response( 200 );
 		};
@@ -253,6 +254,11 @@ class Test_Visualizer_Remote_Fetch extends WP_UnitTestCase {
 				array( '2606:2800:220:1:248:1893:25c8:1946', '93.184.216.34' ),
 				'example.com:443:93.184.216.34',
 			),
+			'pre-IPv6 mixed addresses' => array(
+				'7.56.0',
+				array( '2606:2800:220:1:248:1893:25c8:1946', '93.184.216.34' ),
+				'example.com:443:93.184.216.34',
+			),
 			'legacy IPv6 address'    => array(
 				'7.57.0',
 				array( '2606:2800:220:1:248:1893:25c8:1946' ),
@@ -317,17 +323,21 @@ class Test_Visualizer_Remote_Fetch extends WP_UnitTestCase {
 	 * Header and method policy is applied before dispatch.
 	 */
 	public function test_rejects_unsupported_method_before_request() {
-		$requests = 0;
-		$filter   = function ( $preempt ) use ( &$requests ) {
+		$requests  = 0;
+		$responses = array();
+		$filter    = function ( $preempt ) use ( &$requests ) {
 			$requests++;
-			return $preempt;
+			return $this->response( 200 );
 		};
 		add_filter( 'pre_http_request', $filter );
 
+		foreach ( array( 'CONNECT', 'TRACE', "GET\r\nX-Injected: true" ) as $method ) {
+			$responses[] = Visualizer_Remote_Fetch::request( 'http://93.184.216.34/', array( 'method' => $method ) );
+		}
+
 		remove_filter( 'pre_http_request', $filter );
 
-		foreach ( array( 'CONNECT', 'TRACE', "GET\r\nX-Injected: true" ) as $method ) {
-			$response = Visualizer_Remote_Fetch::request( 'http://93.184.216.34/', array( 'method' => $method ) );
+		foreach ( $responses as $response ) {
 			$this->assertWPError( $response );
 			$this->assertSame( 'visualizer_remote_method', $response->get_error_code() );
 		}

--- a/tests/test-remote-fetch.php
+++ b/tests/test-remote-fetch.php
@@ -145,6 +145,55 @@ class Test_Visualizer_Remote_Fetch extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Cookies set by a response must be available to its same-origin redirect target.
+	 */
+	public function test_carries_response_cookies_on_same_origin_redirect() {
+		$requests = array();
+		$filter   = function ( $preempt, $args ) use ( &$requests ) {
+			$requests[] = $args['cookies'];
+			if ( 1 === count( $requests ) ) {
+				$cookie = new WP_Http_Cookie( 'session=secret; Path=/', 'http://93.184.216.34/start' );
+				return $this->response( 302, array( 'location' => '/next' ), '', array( $cookie ) );
+			}
+			return $this->response( 200 );
+		};
+		add_filter( 'pre_http_request', $filter, 10, 2 );
+
+		$response = Visualizer_Remote_Fetch::request( 'http://93.184.216.34/start' );
+
+		remove_filter( 'pre_http_request', $filter, 10 );
+		$this->assertNotWPError( $response );
+		$this->assertCount( 2, $requests );
+		$this->assertCount( 1, $requests[1] );
+		$this->assertSame( 'session', $requests[1][0]->name );
+	}
+
+	/**
+	 * WordPress accepts request headers as a string, including across redirects.
+	 */
+	public function test_normalizes_string_headers_before_cross_origin_redirect() {
+		$requests = array();
+		$filter   = function ( $preempt, $args ) use ( &$requests ) {
+			$requests[] = $args['headers'];
+			if ( 1 === count( $requests ) ) {
+				return $this->response( 302, array( 'location' => 'http://93.184.216.35/next' ) );
+			}
+			return $this->response( 200 );
+		};
+		add_filter( 'pre_http_request', $filter, 10, 2 );
+
+		$response = Visualizer_Remote_Fetch::request(
+			'http://93.184.216.34/start',
+			array( 'headers' => "Accept: application/json\r\nAuthorization: Bearer secret" )
+		);
+
+		remove_filter( 'pre_http_request', $filter, 10 );
+		$this->assertNotWPError( $response );
+		$this->assertCount( 2, $requests );
+		$this->assertSame( array( 'accept' => 'application/json' ), $requests[1] );
+	}
+
+	/**
 	 * The validated addresses are pinned on the cURL transport only while the request dispatches.
 	 */
 	public function test_pins_validated_addresses_during_dispatch() {
@@ -164,24 +213,104 @@ class Test_Visualizer_Remote_Fetch extends WP_UnitTestCase {
 	}
 
 	/**
-	 * IPv6 addresses use cURL's bracketed CURLOPT_RESOLVE syntax.
+	 * Addresses use syntax supported by the installed cURL version.
+	 *
+	 * @dataProvider curl_resolve_entries
+	 * @param string   $curl_version cURL version.
+	 * @param string[] $ips          Validated addresses.
+	 * @param string   $expected     Expected resolve entry.
 	 */
-	public function test_formats_ipv6_addresses_for_curl_resolve() {
+	public function test_formats_addresses_for_curl_resolve( $curl_version, $ips, $expected ) {
 		$method = new ReflectionMethod( Visualizer_Remote_Fetch::class, 'pin_validated_addresses' );
 		$method->setAccessible( true );
 		$pin = $method->invoke(
 			null,
 			'https://example.com/data.json',
-			array( '93.184.216.34', '2606:2800:220:1:248:1893:25c8:1946' )
+			$ips,
+			$curl_version
 		);
 
 		$this->assertIsCallable( $pin );
 		$reflection = new ReflectionFunction( $pin );
-		$this->assertSame(
-			'example.com:443:93.184.216.34,[2606:2800:220:1:248:1893:25c8:1946]',
-			$reflection->getStaticVariables()['entry']
-		);
+		$this->assertSame( $expected, $reflection->getStaticVariables()['entry'] );
 		remove_action( 'http_api_curl', $pin );
+	}
+
+	/**
+	 * Resolve entries for supported cURL syntax generations.
+	 *
+	 * @return array[]
+	 */
+	public function curl_resolve_entries() {
+		return array(
+			'modern mixed addresses' => array(
+				'7.59.0',
+				array( '93.184.216.34', '2606:2800:220:1:248:1893:25c8:1946' ),
+				'example.com:443:93.184.216.34,[2606:2800:220:1:248:1893:25c8:1946]',
+			),
+			'legacy mixed addresses' => array(
+				'7.58.0',
+				array( '2606:2800:220:1:248:1893:25c8:1946', '93.184.216.34' ),
+				'example.com:443:93.184.216.34',
+			),
+			'legacy IPv6 address'    => array(
+				'7.57.0',
+				array( '2606:2800:220:1:248:1893:25c8:1946' ),
+				'example.com:443:[2606:2800:220:1:248:1893:25c8:1946]',
+			),
+		);
+	}
+
+	/**
+	 * cURL versions without bracketed IPv6 resolve support fail closed for IPv6-only hosts.
+	 */
+	public function test_rejects_ipv6_pinning_on_unsupported_curl() {
+		$method = new ReflectionMethod( Visualizer_Remote_Fetch::class, 'pin_validated_addresses' );
+		$method->setAccessible( true );
+		$response = $method->invoke(
+			null,
+			'https://example.com/data.json',
+			array( '2606:2800:220:1:248:1893:25c8:1946' ),
+			'7.56.0'
+		);
+
+		$this->assertWPError( $response );
+		$this->assertSame( 'visualizer_remote_transport', $response->get_error_code() );
+	}
+
+	/**
+	 * JSON imports retain the established extended request methods.
+	 *
+	 * @dataProvider extended_json_request_methods
+	 * @param string $method HTTP method.
+	 */
+	public function test_allows_extended_json_request_methods( $method ) {
+		$filter = function ( $preempt, $args ) use ( $method ) {
+			$this->assertSame( $method, $args['method'] );
+			return $this->response( 200 );
+		};
+		add_filter( 'pre_http_request', $filter, 10, 2 );
+
+		$response = Visualizer_Remote_Fetch::request( 'http://93.184.216.34/', array( 'method' => $method ) );
+
+		remove_filter( 'pre_http_request', $filter, 10 );
+		$this->assertNotWPError( $response );
+	}
+
+	/**
+	 * Extended JSON request methods.
+	 *
+	 * @return array[]
+	 */
+	public function extended_json_request_methods() {
+		return array(
+			'PUT'      => array( 'PUT' ),
+			'PATCH'    => array( 'PATCH' ),
+			'DELETE'   => array( 'DELETE' ),
+			'HEAD'     => array( 'HEAD' ),
+			'OPTIONS'  => array( 'OPTIONS' ),
+			'PROPFIND' => array( 'PROPFIND' ),
+		);
 	}
 
 	/**
@@ -195,11 +324,13 @@ class Test_Visualizer_Remote_Fetch extends WP_UnitTestCase {
 		};
 		add_filter( 'pre_http_request', $filter );
 
-		$response = Visualizer_Remote_Fetch::request( 'http://93.184.216.34/', array( 'method' => 'DELETE' ) );
-
 		remove_filter( 'pre_http_request', $filter );
-		$this->assertWPError( $response );
-		$this->assertSame( 'visualizer_remote_method', $response->get_error_code() );
+
+		foreach ( array( 'CONNECT', 'TRACE', "GET\r\nX-Injected: true" ) as $method ) {
+			$response = Visualizer_Remote_Fetch::request( 'http://93.184.216.34/', array( 'method' => $method ) );
+			$this->assertWPError( $response );
+			$this->assertSame( 'visualizer_remote_method', $response->get_error_code() );
+		}
 		$this->assertSame( 0, $requests );
 	}
 
@@ -255,6 +386,79 @@ class Test_Visualizer_Remote_Fetch extends WP_UnitTestCase {
 		$this->assertCount( 2, $requests );
 		$this->assertSame( 'http://93.184.216.34/next', $requests[1][0] );
 		$this->assertSame( $headers, $requests[1][1] );
+	}
+
+	/**
+	 * A 301 redirect preserves the request method and body, matching WordPress Requests.
+	 */
+	public function test_301_redirect_preserves_post_method_and_body() {
+		$requests = array();
+		$filter   = function ( $preempt, $args ) use ( &$requests ) {
+			$requests[] = array( $args['method'], isset( $args['body'] ) ? $args['body'] : null );
+			return 1 === count( $requests )
+				? $this->response( 301, array( 'location' => '/next' ) )
+				: $this->response( 200 );
+		};
+		add_filter( 'pre_http_request', $filter, 10, 2 );
+
+		$response = Visualizer_Remote_Fetch::request(
+			'http://93.184.216.34/start',
+			array(
+				'method' => 'POST',
+				'body'   => '{"query":"data"}',
+			)
+		);
+
+		remove_filter( 'pre_http_request', $filter, 10 );
+		$this->assertNotWPError( $response );
+		$this->assertSame(
+			array(
+				array( 'POST', '{"query":"data"}' ),
+				array( 'POST', '{"query":"data"}' ),
+			),
+			$requests
+		);
+	}
+
+	/**
+	 * Browser-compatible redirects switch extended methods to GET without a body.
+	 *
+	 * @dataProvider get_redirect_statuses
+	 * @param int $status Redirect status.
+	 */
+	public function test_browser_redirect_switches_extended_method_to_get( $status ) {
+		$requests = array();
+		$filter   = function ( $preempt, $args ) use ( &$requests, $status ) {
+			$requests[] = array( $args['method'], isset( $args['body'] ) ? $args['body'] : null );
+			return 1 === count( $requests )
+				? $this->response( $status, array( 'location' => '/next' ) )
+				: $this->response( 200 );
+		};
+		add_filter( 'pre_http_request', $filter, 10, 2 );
+
+		$response = Visualizer_Remote_Fetch::request(
+			'http://93.184.216.34/start',
+			array(
+				'method' => 'PATCH',
+				'body'   => '{"query":"data"}',
+			)
+		);
+
+		remove_filter( 'pre_http_request', $filter, 10 );
+		$this->assertNotWPError( $response );
+		$this->assertSame( array( 'GET', null ), $requests[1] );
+	}
+
+	/**
+	 * Redirect statuses that WordPress follows with GET.
+	 *
+	 * @return array[]
+	 */
+	public function get_redirect_statuses() {
+		return array(
+			'302' => array( 302 ),
+			'303' => array( 303 ),
+		);
 	}
 
 	/**
@@ -472,9 +676,10 @@ class Test_Visualizer_Remote_Fetch extends WP_UnitTestCase {
 	 * @param int    $code    Status code.
 	 * @param array  $headers Response headers.
 	 * @param string $body    Response body.
+	 * @param array  $cookies Response cookies.
 	 * @return array
 	 */
-	private function response( $code, $headers = array(), $body = '' ) {
+	private function response( $code, $headers = array(), $body = '', $cookies = array() ) {
 		return array(
 			'headers'  => $headers,
 			'body'     => $body,
@@ -482,7 +687,7 @@ class Test_Visualizer_Remote_Fetch extends WP_UnitTestCase {
 				'code'    => $code,
 				'message' => '',
 			),
-			'cookies'  => array(),
+			'cookies'  => $cookies,
 			'filename' => null,
 		);
 	}


### PR DESCRIPTION
### Summary

- preserve the existing JSON request-method extension point while rejecting malformed methods, `CONNECT`, and `TRACE`
- use cURL-compatible DNS pinning syntax on older supported libcurl versions
- retain same-origin redirect cookies and normalize string-form request headers
- align 301, 302, and 303 redirect method/body handling with WordPress Requests behavior
- add regression coverage for methods, redirects, cookies, headers, and cURL version compatibility

### Will affect visual aspect of the product

NO

### Screenshots

Not applicable.

### Test instructions

1. Start or reuse wp-env with `npm run env:up`.
2. Run the `Test_Visualizer_Remote_Fetch` PHPUnit class in the wp-env test container.
3. Run `composer phpstan`.
4. Run PHPCS against `classes/Visualizer/Remote/Fetch.php` and `tests/test-remote-fetch.php`.

Focused result: 43 tests and 115 assertions pass on PHP 7.4.33.

The full PHPUnit suite currently reports three unrelated existing `Test_Revisions` errors because `tsdk_utmify()` is unavailable; 87 tests run with 241 assertions and 2 skips.

## Check before Pull Request is ready:

* [x] I have written tests and included them in this PR
* [ ] I have run all tests and they pass
* [x] The code passes PHP CodeSniffer for the changed files
* [x] Code meets WordPress Coding Standards
* [x] Security and sanitization requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR
