### PR TITLE
fix: reject cyclic serialized chart data in decode_content()

### DIFF
--- a/classes/Visualizer/Module.php
+++ b/classes/Visualizer/Module.php
@@ -812,7 +812,36 @@ class Visualizer_Module {
 		if ( ! is_string( $content ) ) {
 			return false;
 		}
-		return self::strip_incomplete_objects( unserialize( trim( $content ), array( 'allowed_classes' => false ) ) );
+		$value = unserialize( trim( $content ), array( 'allowed_classes' => false ) );
+		if ( self::contains_references( $value ) ) {
+			return false;
+		}
+		return self::strip_incomplete_objects( $value );
+	}
+
+	/**
+	 * Check decoded arrays for references before recursively processing them.
+	 *
+	 * Cyclic serialized arrays necessarily contain a reference. Rejecting all
+	 * references also prevents shared references from becoming cycles later,
+	 * so strip_incomplete_objects() cannot recurse without terminating.
+	 *
+	 * @param mixed $value The decoded value.
+	 * @return bool Whether the value contains an array reference.
+	 */
+	private static function contains_references( $value ) {
+		if ( ! is_array( $value ) ) {
+			return false;
+		}
+		foreach ( array_keys( $value ) as $key ) {
+			if ( null !== ReflectionReference::fromArrayElement( $value, $key ) ) {
+				return true;
+			}
+			if ( is_array( $value[ $key ] ) && self::contains_references( $value[ $key ] ) ) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**

--- a/tests/test-security-object-injection.php
+++ b/tests/test-security-object-injection.php
@@ -114,6 +114,25 @@ class Test_Security_Object_Injection extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The shared decoder must reject cyclic serialized arrays without recursing.
+	 *
+	 * The allowed_classes guard only blocks objects; a self-referential array
+	 * (R:/r: token) survives it and would drive strip_incomplete_objects() into
+	 * unbounded recursion. decode_content() must reject it up front.
+	 */
+	public function test_decode_content_rejects_cyclic_arrays() {
+		$this->assertFalse(
+			Visualizer_Module::decode_content( 'a:1:{i:0;R:1;}' ),
+			'decode_content() must reject cyclic arrays.'
+		);
+		$this->assertSame(
+			array( 'marker' => 'R:1;' ),
+			Visualizer_Module::decode_content( serialize( array( 'marker' => 'R:1;' ) ) ),
+			'Reference-like text inside strings must remain valid.'
+		);
+	}
+
+	/**
 	 * The Utility pie/polarArea render palette call site must not instantiate objects.
 	 *
 	 * Covers the public global-style filter seam and preserves the trimming


### PR DESCRIPTION
### Summary

Ports the `contains_references()` guard from Visualizer Pro (Codeinwp/visualizer-pro#600) into the free plugin. `unserialize()` with `allowed_classes => false` blocks object injection but not references, so a self-referential serialized array survived decoding and drove `strip_incomplete_objects()` into unbounded recursion — a memory/stack-exhaustion DoS reachable from any render/export/clone path.

`decode_content()` now walks the decoded value with `ReflectionReference::fromArrayElement()` (PHP 7.4+, matching the plugin's declared minimum) and returns `false` when any array element is a reference. Cyclic structures necessarily contain a reference, and rejecting all references also prevents shared references from becoming cycles later.

### Will affect visual aspect of the product

NO

### Test instructions

- `vendor/bin/phpunit --filter Test_Security_Object_Injection` — a cyclic serialized array is rejected by `decode_content()` instead of recursing.
- Manually: charts with existing (non-cyclic) serialized data still render, export, and clone.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed

🤖 Generated with [Claude Code](https://claude.com/claude-code)