### PR TITLE
fix: check per-chart edit_post capability in chart_data REST field

### DIFF
--- a/classes/Visualizer/Gutenberg/Block.php
+++ b/classes/Visualizer/Gutenberg/Block.php
@@ -276,7 +276,7 @@ class Visualizer_Gutenberg_Block {
 	 * Get Post Meta Fields
 	 */
 	public function get_visualizer_data( $post ) {
-		if ( ! current_user_can( 'edit_post', $post['id'] ) ) {
+		if ( ! Visualizer_Module::can_edit_chart( $post['id'] ) ) {
 			return false;
 		}
 

--- a/classes/Visualizer/Gutenberg/Block.php
+++ b/classes/Visualizer/Gutenberg/Block.php
@@ -276,7 +276,7 @@ class Visualizer_Gutenberg_Block {
 	 * Get Post Meta Fields
 	 */
 	public function get_visualizer_data( $post ) {
-		if ( ! current_user_can( 'edit_posts' ) ) {
+		if ( ! current_user_can( 'edit_post', $post['id'] ) ) {
 			return false;
 		}
 

--- a/tests/test-chart-data-permissions.php
+++ b/tests/test-chart-data-permissions.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * WordPress unit test plugin.
+ *
+ * @package     visualizer
+ * @subpackage  Tests
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * Test the capability check on the chart_data REST field callback.
+ */
+class Test_Visualizer_Chart_Data_Permissions extends WP_UnitTestCase {
+
+	/**
+	 * Create a chart owned by the given user.
+	 *
+	 * @param int $author_id The chart author.
+	 * @return int The chart id.
+	 */
+	private function create_chart( $author_id ) {
+		$chart_id = self::factory()->post->create(
+			array(
+				'post_type'    => Visualizer_Plugin::CPT_VISUALIZER,
+				'post_author'  => $author_id,
+				'post_content' => wp_slash( serialize( array( array( 'Label' ), array( 'Value' ) ) ) ),
+			)
+		);
+		update_post_meta( $chart_id, Visualizer_Plugin::CF_CHART_TYPE, 'line' );
+		update_post_meta( $chart_id, Visualizer_Plugin::CF_SETTINGS, array() );
+		update_post_meta( $chart_id, Visualizer_Plugin::CF_SERIES, array( array( 'label' => 'Label', 'type' => 'string' ) ) );
+		return $chart_id;
+	}
+
+	/**
+	 * A contributor must not read another user's chart configuration.
+	 */
+	public function test_contributor_cannot_read_others_chart_data() {
+		$author_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$chart_id  = $this->create_chart( $author_id );
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'contributor' ) ) );
+
+		$result = Visualizer_Gutenberg_Block::get_instance()->get_visualizer_data( array( 'id' => $chart_id ) );
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * The chart author can still read their own chart configuration.
+	 */
+	public function test_author_can_read_own_chart_data() {
+		$author_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$chart_id  = $this->create_chart( $author_id );
+
+		wp_set_current_user( $author_id );
+
+		$result = Visualizer_Gutenberg_Block::get_instance()->get_visualizer_data( array( 'id' => $chart_id ) );
+		$this->assertIsArray( $result );
+	}
+}

--- a/tests/test-chart-data-permissions.php
+++ b/tests/test-chart-data-permissions.php
@@ -22,6 +22,7 @@ class Test_Visualizer_Chart_Data_Permissions extends WP_UnitTestCase {
 		$chart_id = self::factory()->post->create(
 			array(
 				'post_type'    => Visualizer_Plugin::CPT_VISUALIZER,
+				'post_status'  => 'publish',
 				'post_author'  => $author_id,
 				'post_content' => wp_slash( serialize( array( array( 'Label' ), array( 'Value' ) ) ) ),
 			)
@@ -47,12 +48,27 @@ class Test_Visualizer_Chart_Data_Permissions extends WP_UnitTestCase {
 
 	/**
 	 * The chart author can still read their own chart configuration.
+	 *
+	 * Charts are always published on save, so a Contributor author must pass
+	 * the check even without the edit_published_posts capability.
 	 */
-	public function test_author_can_read_own_chart_data() {
-		$author_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+	public function test_contributor_author_can_read_own_chart_data() {
+		$author_id = self::factory()->user->create( array( 'role' => 'contributor' ) );
 		$chart_id  = $this->create_chart( $author_id );
 
 		wp_set_current_user( $author_id );
+
+		$result = Visualizer_Gutenberg_Block::get_instance()->get_visualizer_data( array( 'id' => $chart_id ) );
+		$this->assertIsArray( $result );
+	}
+
+	/**
+	 * An editor can read any chart configuration.
+	 */
+	public function test_editor_can_read_others_chart_data() {
+		$chart_id = $this->create_chart( self::factory()->user->create( array( 'role' => 'contributor' ) ) );
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
 
 		$result = Visualizer_Gutenberg_Block::get_instance()->get_visualizer_data( array( 'id' => $chart_id ) );
 		$this->assertIsArray( $result );


### PR DESCRIPTION
Any logged-in user with the `edit_posts` capability (Contributor and above) could read the full backend configuration of any chart on the site — data source query, series/settings, and JSON endpoint URLs with their authentication headers — via `GET /wp-json/wp/v2/visualizer/{chart_id}`, because the `chart_data` REST field callback only checked the generic `edit_posts` capability. Reported in Codeinwp/visualizer-pro#605.

## What changed

- **`chart_data` REST field guard** — `get_visualizer_data()` now checks `Visualizer_Module::can_edit_chart()` against the requested chart instead of the generic `current_user_can( 'edit_posts' )`. Access is allowed for the chart's author and for users with `edit_others_posts` (Editor and above). The existing `can_edit_chart()` helper is used instead of a bare `edit_post` check because charts are force-published on save and Contributors lack `edit_published_posts` — a bare check would lock Contributor authors out of their own charts.

- **Regression test** — `tests/test-chart-data-permissions.php` asserts a Contributor gets `false` for another user's published chart, a Contributor author still receives their own chart's data, and an Editor can read any chart.

## chart_data request flow

```mermaid
flowchart LR
    A[GET /wp/v2/visualizer/id] --> B[chart_data field callback]
    B --> C{Changed:<br/>can_edit_chart —<br/>author or Editor+?}:::changed
    C -- Yes --> D[Return chart config]
    C -- No --> E[Return false]

    classDef changed fill:#9a6700,color:#fff,stroke:#5c3d00,stroke-width:3px,stroke-dasharray:6 3
```

## QA

1. As an Administrator, create and publish a chart, and note its post ID.

2. As a Contributor, request the chart over REST (e.g. from the browser console while logged in):
   ```js
   wp.apiFetch( { path: '/wp/v2/visualizer/<chart_id>' } ).then( console.log );
   ```
   **Expect:** `chart_data` is `false` — no source query, settings, or endpoint headers in the response.

3. As the chart's author (or an Editor/Administrator), repeat the same request.
   **Expect:** `chart_data` contains the chart configuration and the chart still loads normally in the Gutenberg block editor.

4. As a Contributor, create a chart of your own, then repeat the request for that chart's ID.
   **Expect:** `chart_data` contains the chart configuration — Contributor authors keep access to their own charts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
