### PR TITLE
fix: enforce per-chart authorization in AI Builder endpoints

### DIFF
--- a/classes/Visualizer/Module.php
+++ b/classes/Visualizer/Module.php
@@ -650,7 +650,7 @@ class Visualizer_Module {
 				$class_name = $id . $name;
 				$properties = implode( ' !important; ', array_filter( $attributes ) );
 				if ( ! empty( $properties ) ) {
-					$css    .= '.' . $class_name . ' {' . $properties . ' !important;}';
+					$css    .= wp_strip_all_tags( '.' . $class_name . ' {' . $properties . ' !important;}' );
 					$classes[ $name ] = $class_name;
 				}
 			}

--- a/classes/Visualizer/Module/AIBuilder.php
+++ b/classes/Visualizer/Module/AIBuilder.php
@@ -100,7 +100,7 @@ class Visualizer_Module_AIBuilder extends Visualizer_Module {
 	 * @param int $chart_id Chart ID.
 	 */
 	private function _verify_chart_access( $chart_id ): void {
-		if ( ! current_user_can( 'edit_post', $chart_id ) ) {
+		if ( ! self::can_edit_chart( $chart_id ) ) {
 			wp_send_json_error( array( 'message' => __( 'Unauthorized.', 'visualizer' ) ), 403 );
 		}
 	}
@@ -502,6 +502,10 @@ class Visualizer_Module_AIBuilder extends Visualizer_Module {
 			}
 		}
 
+		if ( ! empty( $workflow_id ) ) {
+			set_transient( 'viz_ai_wf_' . $workflow_id, get_current_user_id(), 6 * HOUR_IN_SECONDS );
+		}
+
 		wp_send_json_success(
 			array(
 				'workflow_id' => $workflow_id,
@@ -522,6 +526,10 @@ class Visualizer_Module_AIBuilder extends Visualizer_Module {
 		$workflow_id = isset( $_POST['workflow_id'] ) ? sanitize_text_field( wp_unslash( $_POST['workflow_id'] ) ) : '';
 		if ( empty( $workflow_id ) ) {
 			wp_send_json_error( array( 'message' => __( 'Missing workflow ID.', 'visualizer' ) ) );
+		}
+
+		if ( (int) get_transient( 'viz_ai_wf_' . $workflow_id ) !== get_current_user_id() ) {
+			wp_send_json_error( array( 'message' => __( 'Unauthorized.', 'visualizer' ) ), 403 );
 		}
 
 		$agents_url    = VISUALIZER_AGENTS_URL;

--- a/classes/Visualizer/Module/Wizard.php
+++ b/classes/Visualizer/Module/Wizard.php
@@ -153,6 +153,12 @@ class Visualizer_Module_Wizard extends Visualizer_Module {
 	 * @return bool|void
 	 */
 	public function dismissWizard( $redirect_to_dashboard = true ) {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You do not have permission to perform this action.', 'visualizer' ), '', array( 'response' => 403 ) );
+		}
+		if ( false !== $redirect_to_dashboard ) {
+			check_admin_referer( 'visualizer_dismiss_wizard' );
+		}
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$status = isset( $_REQUEST['status'] ) ? (int) $_REQUEST['status'] : 0;
 		update_option( 'visualizer_fresh_install', $status );
@@ -169,6 +175,9 @@ class Visualizer_Module_Wizard extends Visualizer_Module {
 	 */
 	public function visualizer_wizard_step_process() {
 		check_ajax_referer( VISUALIZER_ABSPATH, 'security' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json( array( 'status' => 0 ), 403 );
+		}
 		$step = ! empty( $_POST['step'] ) ? sanitize_text_field( wp_unslash( $_POST['step'] ) ) : 1;
 		switch ( $step ) {
 			case 'step_2':

--- a/templates/setup-wizard.php
+++ b/templates/setup-wizard.php
@@ -6,12 +6,15 @@
  * @package Templates
  */
 
-$dashboard_url = add_query_arg(
-	array(
-		'action' => 'visualizer_dismiss_wizard',
-		'status' => 0,
+$dashboard_url = wp_nonce_url(
+	add_query_arg(
+		array(
+			'action' => 'visualizer_dismiss_wizard',
+			'status' => 0,
+		),
+		admin_url( 'admin.php' )
 	),
-	admin_url( 'admin.php' )
+	'visualizer_dismiss_wizard'
 );
 
 $chart_id           = ! empty( $this->wizard_data['chart_id'] ) ? (int) $this->wizard_data['chart_id'] : '';

--- a/tests/e2e/config/mu-plugins/plant-chart-settings.php
+++ b/tests/e2e/config/mu-plugins/plant-chart-settings.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * E2E test helper (loaded as an mu-plugin via .wp-env.json).
+ *
+ * Lets specs plant chart data/settings meta directly, e.g. a stored-XSS
+ * payload in `customcss` that UI save flows strip on submission, so
+ * render-time sanitization can be verified.
+ */
+add_action(
+	'rest_api_init',
+	function () {
+		register_rest_route(
+			'visualizer-e2e/v1',
+			'/chart-settings/(?P<id>\d+)',
+			array(
+				'methods'             => 'POST',
+				'permission_callback' => function () {
+					return current_user_can( 'manage_options' );
+				},
+				'callback'            => function ( WP_REST_Request $request ) {
+					$chart_id = (int) $request['id'];
+					$body     = $request->get_json_params();
+					if ( isset( $body['settings'] ) ) {
+						update_post_meta( $chart_id, 'visualizer-settings', $body['settings'] );
+					}
+					if ( isset( $body['series'] ) ) {
+						update_post_meta( $chart_id, 'visualizer-series', $body['series'] );
+					}
+					if ( isset( $body['content'] ) ) {
+						wp_update_post(
+							array(
+								'ID'           => $chart_id,
+								'post_content' => maybe_serialize( $body['content'] ),
+							)
+						);
+					}
+					return array( 'ok' => true );
+				},
+			)
+		);
+	}
+);

--- a/tests/e2e/specs/ai-builder-auth.spec.js
+++ b/tests/e2e/specs/ai-builder-auth.spec.js
@@ -1,0 +1,138 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+const CONTRIBUTOR = { username: 'viz_contributor', password: 'viz-contributor-pass', email: 'viz-contributor@example.com' };
+const EDITOR = { username: 'viz_editor', password: 'viz-editor-pass', email: 'viz-editor@example.com' };
+
+let adminChartId;
+let contributorId;
+let editorId;
+
+/**
+ * Log in via wp-login in a fresh context and return the page.
+ */
+async function loginAs( browser, baseURL, credentials ) {
+	const context = await browser.newContext( { baseURL } );
+	const page = await context.newPage();
+	await page.goto( '/wp-login.php' );
+	await page.fill( '#user_login', credentials.username );
+	await page.fill( '#user_pass', credentials.password );
+	await page.click( '#wp-submit' );
+	await page.waitForURL( '**/wp-admin/**' );
+	return { context, page };
+}
+
+/**
+ * Read the AI Builder nonce localized on the Visualizer library page.
+ */
+async function getAiNonce( page ) {
+	await page.goto( '/wp-admin/admin.php?page=visualizer' );
+	return page.evaluate( () => {
+		if ( window.vizAIBuilder && window.vizAIBuilder.nonce ) {
+			return window.vizAIBuilder.nonce;
+		}
+		const match = document.documentElement.innerHTML.match( /"nonce":"([a-f0-9]+)"/ );
+		return match ? match[ 1 ] : null;
+	} );
+}
+
+/**
+ * Call an admin-ajax action using the page's session cookies.
+ */
+async function aiAjax( page, action, data ) {
+	const response = await page.request.post( '/wp-admin/admin-ajax.php', {
+		form: { action, ...data },
+	} );
+	return { status: response.status(), body: await response.json() };
+}
+
+test.describe( 'AI Builder authorization', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		const contributor = await requestUtils.rest( {
+			method: 'POST',
+			path: '/wp/v2/users',
+			data: { ...CONTRIBUTOR, roles: [ 'contributor' ] },
+		} );
+		contributorId = contributor.id;
+
+		const editor = await requestUtils.rest( {
+			method: 'POST',
+			path: '/wp/v2/users',
+			data: { ...EDITOR, roles: [ 'editor' ] },
+		} );
+		editorId = editor.id;
+
+		const chart = await requestUtils.rest( {
+			method: 'POST',
+			path: '/wp/v2/visualizer',
+			data: { title: 'Admin chart', status: 'publish' },
+		} );
+		adminChartId = chart.id;
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		if ( adminChartId ) {
+			await requestUtils.rest( { method: 'DELETE', path: `/wp/v2/visualizer/${ adminChartId }`, params: { force: true } } );
+		}
+		for ( const [ id, user ] of [ [ contributorId, CONTRIBUTOR ], [ editorId, EDITOR ] ] ) {
+			if ( id ) {
+				await requestUtils.rest( { method: 'DELETE', path: `/wp/v2/users/${ id }`, params: { force: true, reassign: 1 } } );
+			}
+		}
+	} );
+
+	test( 'denies read/write/nonce endpoints on another user\'s chart', async ( { browser } ) => {
+		const baseURL = test.info().project.use.baseURL;
+		const { context, page } = await loginAs( browser, baseURL, CONTRIBUTOR );
+		const nonce = await getAiNonce( page );
+		expect( nonce ).toBeTruthy();
+
+		for ( const action of [ 'visualizer-ai-fetch', 'visualizer-ai-chart-nonce', 'visualizer-ai-save' ] ) {
+			const { status, body } = await aiAjax( page, action, { nonce, chart_id: adminChartId, code: 'x' } );
+			expect( status, action ).toBe( 403 );
+			expect( body.data.message, action ).toBe( 'Unauthorized.' );
+		}
+
+		await context.close();
+	} );
+
+	test( 'denies polling a workflow owned by someone else', async ( { browser } ) => {
+		const baseURL = test.info().project.use.baseURL;
+		const { context, page } = await loginAs( browser, baseURL, CONTRIBUTOR );
+		const nonce = await getAiNonce( page );
+
+		const { status, body } = await aiAjax( page, 'visualizer-ai-status', { nonce, workflow_id: 'foreign-workflow-id' } );
+		expect( status ).toBe( 403 );
+		expect( body.data.message ).toBe( 'Unauthorized.' );
+
+		await context.close();
+	} );
+
+	test( 'allows a contributor to use their own chart', async ( { browser } ) => {
+		const baseURL = test.info().project.use.baseURL;
+		const { context, page } = await loginAs( browser, baseURL, CONTRIBUTOR );
+		const nonce = await getAiNonce( page );
+
+		const created = await aiAjax( page, 'visualizer-ai-create', { nonce } );
+		expect( created.body.success ).toBe( true );
+		const ownChartId = created.body.data.chart_id;
+
+		const fetched = await aiAjax( page, 'visualizer-ai-fetch', { nonce, chart_id: ownChartId } );
+		expect( fetched.body.success ).toBe( true );
+
+		await context.close();
+	} );
+
+	test( 'allows an editor to read another user\'s chart', async ( { browser } ) => {
+		const baseURL = test.info().project.use.baseURL;
+		const { context, page } = await loginAs( browser, baseURL, EDITOR );
+		const nonce = await getAiNonce( page );
+
+		const { body } = await aiAjax( page, 'visualizer-ai-fetch', { nonce, chart_id: adminChartId } );
+		expect( body.success ).toBe( true );
+
+		await context.close();
+	} );
+} );

--- a/tests/e2e/specs/ai-builder-auth.spec.js
+++ b/tests/e2e/specs/ai-builder-auth.spec.js
@@ -7,6 +7,7 @@ const CONTRIBUTOR = { username: 'viz_contributor', password: 'viz-contributor-pa
 const EDITOR = { username: 'viz_editor', password: 'viz-editor-pass', email: 'viz-editor@example.com' };
 
 let adminChartId;
+let contributorChartId;
 let contributorId;
 let editorId;
 
@@ -16,15 +17,22 @@ let editorId;
  * Uses a raw POST with redirects off: the auth cookie is set by the 302
  * response, so we never have to load the wp-admin dashboard (which can
  * stall on external feed widgets in CI).
+ *
+ * The context starts with an empty storage state: browser.newContext()
+ * otherwise inherits the project's admin cookies, so a login that silently
+ * failed would leave these requests running as admin. That also means no
+ * wordpress_test_cookie, hence no `testcookie` field in the form.
  */
 async function loginAs( browser, baseURL, credentials ) {
-	const context = await browser.newContext( { baseURL } );
+	const context = await browser.newContext( {
+		baseURL,
+		storageState: { cookies: [], origins: [] },
+	} );
 	const response = await context.request.post( '/wp-login.php', {
 		form: {
 			log: credentials.username,
 			pwd: credentials.password,
 			'wp-submit': 'Log In',
-			testcookie: '1',
 		},
 		maxRedirects: 0,
 	} );
@@ -84,8 +92,10 @@ test.describe( 'AI Builder authorization', () => {
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {
-		if ( adminChartId ) {
-			await requestUtils.rest( { method: 'DELETE', path: `/wp/v2/visualizer/${ adminChartId }`, params: { force: true } } );
+		for ( const id of [ adminChartId, contributorChartId ] ) {
+			if ( id ) {
+				await requestUtils.rest( { method: 'DELETE', path: `/wp/v2/visualizer/${ id }`, params: { force: true } } );
+			}
 		}
 		for ( const [ id, user ] of [ [ contributorId, CONTRIBUTOR ], [ editorId, EDITOR ] ] ) {
 			if ( id ) {
@@ -128,9 +138,9 @@ test.describe( 'AI Builder authorization', () => {
 
 		const created = await aiAjax( page, 'visualizer-ai-create', { nonce } );
 		expect( created.body.success ).toBe( true );
-		const ownChartId = created.body.data.chart_id;
+		contributorChartId = created.body.data.chart_id;
 
-		const fetched = await aiAjax( page, 'visualizer-ai-fetch', { nonce, chart_id: ownChartId } );
+		const fetched = await aiAjax( page, 'visualizer-ai-fetch', { nonce, chart_id: contributorChartId } );
 		expect( fetched.body.success ).toBe( true );
 
 		await context.close();

--- a/tests/e2e/specs/ai-builder-auth.spec.js
+++ b/tests/e2e/specs/ai-builder-auth.spec.js
@@ -12,15 +12,26 @@ let editorId;
 
 /**
  * Log in via wp-login in a fresh context and return the page.
+ *
+ * Uses a raw POST with redirects off: the auth cookie is set by the 302
+ * response, so we never have to load the wp-admin dashboard (which can
+ * stall on external feed widgets in CI).
  */
 async function loginAs( browser, baseURL, credentials ) {
 	const context = await browser.newContext( { baseURL } );
+	const response = await context.request.post( '/wp-login.php', {
+		form: {
+			log: credentials.username,
+			pwd: credentials.password,
+			'wp-submit': 'Log In',
+			testcookie: '1',
+		},
+		maxRedirects: 0,
+	} );
+	if ( response.status() !== 302 ) {
+		throw new Error( `Login as ${ credentials.username } failed with status ${ response.status() }` );
+	}
 	const page = await context.newPage();
-	await page.goto( '/wp-login.php' );
-	await page.fill( '#user_login', credentials.username );
-	await page.fill( '#user_pass', credentials.password );
-	await page.click( '#wp-submit' );
-	await page.waitForURL( '**/wp-admin/**' );
 	return { context, page };
 }
 

--- a/tests/e2e/specs/custom-css.spec.js
+++ b/tests/e2e/specs/custom-css.spec.js
@@ -1,0 +1,51 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+let chartId;
+
+test.describe( 'Custom CSS sanitization', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		const chart = await requestUtils.rest( {
+			method: 'POST',
+			path: '/wp/v2/visualizer',
+			data: { title: 'Custom CSS payload chart', status: 'publish' },
+		} );
+		chartId = chart.id;
+
+		await requestUtils.rest( {
+			method: 'POST',
+			path: `/visualizer-e2e/v1/chart-settings/${ chartId }`,
+			data: {
+				settings: {
+					customcss: {
+						title: {
+							color: 'red</style><script>window.vizXss=1</script><style>',
+							'font-size': '12px',
+						},
+					},
+				},
+			},
+		} );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		if ( chartId ) {
+			await requestUtils.rest( { method: 'DELETE', path: `/wp/v2/visualizer/${ chartId }`, params: { force: true } } );
+		}
+	} );
+
+	test( 'strips tags from chart custom CSS on the library page', async ( { admin, page } ) => {
+		await admin.visitAdminPage( 'admin.php?page=visualizer' );
+
+		const styleBlock = page.locator( `#customcss-visualizer-${ chartId }` );
+		await expect( styleBlock ).toHaveCount( 1 );
+		// Legitimate rules survive sanitization. <style> has no innerText, so read textContent.
+		const css = await styleBlock.textContent();
+		expect( css ).toContain( 'font-size: 12px' );
+		expect( css ).not.toContain( '<script' );
+		// The injected script must not have executed.
+		expect( await page.evaluate( () => window.vizXss ) ).toBeUndefined();
+	} );
+} );

--- a/tests/e2e/specs/wizard-auth.spec.js
+++ b/tests/e2e/specs/wizard-auth.spec.js
@@ -24,15 +24,22 @@ test.describe( 'Setup wizard authorization', () => {
 	} );
 
 	test( 'denies wizard dismissal for non-admin users', async ( { browser } ) => {
-		const context = await browser.newContext( { baseURL: test.info().project.use.baseURL } );
+		// Empty storage state: browser.newContext() otherwise inherits the
+		// project's admin cookies, so a login that silently failed would leave
+		// the request authenticated as admin and the assertion below moot.
+		const context = await browser.newContext( {
+			baseURL: test.info().project.use.baseURL,
+			storageState: { cookies: [], origins: [] },
+		} );
 		// POST wp-login with redirects off: the auth cookie is set by the 302
 		// response, so we never load the wp-admin dashboard (can stall in CI).
+		// No `testcookie` field: WP only accepts it when the context already
+		// holds wordpress_test_cookie, which this one deliberately does not.
 		const loginResponse = await context.request.post( '/wp-login.php', {
 			form: {
 				log: CONTRIBUTOR.username,
 				pwd: CONTRIBUTOR.password,
 				'wp-submit': 'Log In',
-				testcookie: '1',
 			},
 			maxRedirects: 0,
 		} );

--- a/tests/e2e/specs/wizard-auth.spec.js
+++ b/tests/e2e/specs/wizard-auth.spec.js
@@ -1,0 +1,46 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+const CONTRIBUTOR = { username: 'viz_wiz_contributor', password: 'viz-wiz-contributor-pass', email: 'viz-wiz-contributor@example.com' };
+
+let contributorId;
+
+test.describe( 'Setup wizard authorization', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		const contributor = await requestUtils.rest( {
+			method: 'POST',
+			path: '/wp/v2/users',
+			data: { ...CONTRIBUTOR, roles: [ 'contributor' ] },
+		} );
+		contributorId = contributor.id;
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		if ( contributorId ) {
+			await requestUtils.rest( { method: 'DELETE', path: `/wp/v2/users/${ contributorId }`, params: { force: true, reassign: 1 } } );
+		}
+	} );
+
+	test( 'denies wizard dismissal for non-admin users', async ( { browser } ) => {
+		const context = await browser.newContext( { baseURL: test.info().project.use.baseURL } );
+		const page = await context.newPage();
+		await page.goto( '/wp-login.php' );
+		await page.fill( '#user_login', CONTRIBUTOR.username );
+		await page.fill( '#user_pass', CONTRIBUTOR.password );
+		await page.click( '#wp-submit' );
+		await page.waitForURL( '**/wp-admin/**' );
+
+		const response = await page.goto( '/wp-admin/admin.php?action=visualizer_dismiss_wizard&status=1' );
+		expect( response.status() ).toBe( 403 );
+
+		await context.close();
+	} );
+
+	test( 'requires a nonce for wizard dismissal', async ( { page } ) => {
+		// Logged in as admin (default storage state) but without a nonce.
+		const response = await page.goto( '/wp-admin/admin.php?action=visualizer_dismiss_wizard&status=1' );
+		expect( response.status() ).toBe( 403 );
+	} );
+} );

--- a/tests/e2e/specs/wizard-auth.spec.js
+++ b/tests/e2e/specs/wizard-auth.spec.js
@@ -25,13 +25,20 @@ test.describe( 'Setup wizard authorization', () => {
 
 	test( 'denies wizard dismissal for non-admin users', async ( { browser } ) => {
 		const context = await browser.newContext( { baseURL: test.info().project.use.baseURL } );
-		const page = await context.newPage();
-		await page.goto( '/wp-login.php' );
-		await page.fill( '#user_login', CONTRIBUTOR.username );
-		await page.fill( '#user_pass', CONTRIBUTOR.password );
-		await page.click( '#wp-submit' );
-		await page.waitForURL( '**/wp-admin/**' );
+		// POST wp-login with redirects off: the auth cookie is set by the 302
+		// response, so we never load the wp-admin dashboard (can stall in CI).
+		const loginResponse = await context.request.post( '/wp-login.php', {
+			form: {
+				log: CONTRIBUTOR.username,
+				pwd: CONTRIBUTOR.password,
+				'wp-submit': 'Log In',
+				testcookie: '1',
+			},
+			maxRedirects: 0,
+		} );
+		expect( loginResponse.status() ).toBe( 302 );
 
+		const page = await context.newPage();
 		const response = await page.goto( '/wp-admin/admin.php?action=visualizer_dismiss_wizard&status=1' );
 		expect( response.status() ).toBe( 403 );
 

--- a/tests/test-ajax.php
+++ b/tests/test-ajax.php
@@ -202,6 +202,257 @@ class Test_Visualizer_Ajax extends WP_Ajax_UnitTestCase {
 	}
 
 	/**
+	 * Test that a chart author keeps access to their own published chart, which
+	 * the edit_post meta capability alone denies for a contributor.
+	 */
+	public function test_ai_builder_allows_author_on_own_published_chart() {
+		$chart_id = $this->factory->post->create(
+			array(
+				'post_type'   => Visualizer_Plugin::CPT_VISUALIZER,
+				'post_status' => 'publish',
+				'post_author' => $this->contibutor_user_id,
+			)
+		);
+		wp_set_current_user( $this->contibutor_user_id );
+
+		$_POST = array(
+			'chart_id' => $chart_id,
+			'nonce'    => wp_create_nonce( 'visualizer-ai-builder' ),
+		);
+
+		try {
+			$this->_handleAjax( 'visualizer-ai-chart-nonce' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			// Expected after wp_send_json_success().
+		}
+
+		$response = json_decode( $this->_last_response );
+		$this->assertTrue( $response->success );
+	}
+
+	/**
+	 * Test that the author bypass is bounded to charts: a post the user owns
+	 * but which is not a chart must not be reachable through the AI Builder.
+	 */
+	public function test_ai_builder_rejects_own_post_that_is_not_a_chart() {
+		$post_id = $this->factory->post->create(
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'draft',
+				'post_author' => $this->contibutor_user_id,
+			)
+		);
+		wp_set_current_user( $this->contibutor_user_id );
+
+		$_POST = array(
+			'chart_id' => $post_id,
+			'nonce'    => wp_create_nonce( 'visualizer-ai-builder' ),
+		);
+
+		try {
+			$this->_handleAjax( 'visualizer-ai-chart-nonce' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			// Expected after wp_send_json_error().
+		}
+
+		$response = json_decode( $this->_last_response );
+		$this->assertFalse( $response->success );
+		$this->assertSame( 'Unauthorized.', $response->data->message );
+	}
+
+	/**
+	 * Test that a started workflow is bound to the user who started it: the
+	 * owner can poll its status, anybody else is rejected.
+	 */
+	public function test_ai_builder_binds_workflow_to_the_user_who_started_it() {
+		$chart_id = $this->factory->post->create(
+			array(
+				'post_type'   => Visualizer_Plugin::CPT_VISUALIZER,
+				'post_status' => 'draft',
+				'post_author' => $this->contibutor_user_id,
+			)
+		);
+		wp_set_current_user( $this->contibutor_user_id );
+
+		$agents_response = function () {
+			return array(
+				'headers'  => array(),
+				'cookies'  => array(),
+				'body'     => wp_json_encode(
+					array(
+						'workflowId' => 'wf-test-1',
+						'status'     => 'completed',
+					)
+				),
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+			);
+		};
+		add_filter( 'pre_http_request', $agents_response );
+
+		try {
+			$_POST = array(
+				'chart_id' => $chart_id,
+				'nonce'    => wp_create_nonce( 'visualizer-ai-builder' ),
+				'series'   => '[{"label":"Label","type":"string"}]',
+				'data'     => '[["A"]]',
+			);
+			try {
+				$this->_handleAjax( 'visualizer-ai-generate' );
+			} catch ( WPAjaxDieContinueException $e ) {
+				// Expected after wp_send_json_success().
+			}
+
+			$response = json_decode( $this->_last_response );
+			$this->assertTrue( $response->success );
+			$this->assertSame( 'wf-test-1', $response->data->workflow_id );
+			$this->assertSame( $this->contibutor_user_id, (int) get_transient( 'viz_ai_wf_wf-test-1' ) );
+
+			// The owner can poll it. dieHandler() appends to _last_response, so
+			// it has to be reset before each further call.
+			$this->_last_response = '';
+			$_POST                = array(
+				'workflow_id' => 'wf-test-1',
+				'nonce'       => wp_create_nonce( 'visualizer-ai-builder' ),
+			);
+			try {
+				$this->_handleAjax( 'visualizer-ai-status' );
+			} catch ( WPAjaxDieContinueException $e ) {
+				// Expected after wp_send_json_success().
+			}
+			$response = json_decode( $this->_last_response );
+			$this->assertTrue( $response->success );
+			$this->assertSame( 'completed', $response->data->status );
+
+			// Another user cannot.
+			wp_set_current_user( $this->admin_user_id );
+			$this->_last_response = '';
+			$_POST                = array(
+				'workflow_id' => 'wf-test-1',
+				'nonce'       => wp_create_nonce( 'visualizer-ai-builder' ),
+			);
+			try {
+				$this->_handleAjax( 'visualizer-ai-status' );
+			} catch ( WPAjaxDieContinueException $e ) {
+				// Expected after wp_send_json_error().
+			}
+			$response = json_decode( $this->_last_response );
+			$this->assertFalse( $response->success );
+			$this->assertSame( 'Unauthorized.', $response->data->message );
+		} finally {
+			remove_filter( 'pre_http_request', $agents_response );
+			delete_transient( 'viz_ai_wf_wf-test-1' );
+		}
+	}
+
+	/**
+	 * Test that the AI Builder database query source requires a Pro license.
+	 */
+	public function test_ai_builder_db_query_requires_pro() {
+		wp_set_current_user( $this->admin_user_id );
+		$chart_id = $this->factory->post->create(
+			array(
+				'post_type'   => Visualizer_Plugin::CPT_VISUALIZER,
+				'post_status' => 'draft',
+				'post_author' => $this->admin_user_id,
+			)
+		);
+
+		add_filter( 'visualizer_is_pro', '__return_false' );
+
+		$_POST = array(
+			'chart_id'    => $chart_id,
+			'nonce'       => wp_create_nonce( 'visualizer-ai-upload-' . $chart_id ),
+			'source_type' => 'db_query',
+			'db_query'    => 'SELECT ID FROM ' . $GLOBALS['wpdb']->prefix . 'posts',
+		);
+
+		try {
+			$this->_handleAjax( 'visualizer-ai-upload' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			// Expected after wp_send_json_error().
+		} finally {
+			remove_filter( 'visualizer_is_pro', '__return_false' );
+		}
+
+		$response = json_decode( $this->_last_response );
+		$this->assertFalse( $response->success );
+		$this->assertSame( 'Action not allowed for this user.', $response->data->message );
+	}
+
+	/**
+	 * Test that a non-super-admin cannot use the AI Builder database query
+	 * source even with an active Pro license.
+	 */
+	public function test_ai_builder_db_query_requires_super_admin() {
+		$this->enable_pro();
+		wp_set_current_user( $this->contibutor_user_id );
+		$chart_id = $this->factory->post->create(
+			array(
+				'post_type'   => Visualizer_Plugin::CPT_VISUALIZER,
+				'post_status' => 'draft',
+				'post_author' => $this->contibutor_user_id,
+			)
+		);
+
+		$_POST = array(
+			'chart_id'    => $chart_id,
+			'nonce'       => wp_create_nonce( 'visualizer-ai-upload-' . $chart_id ),
+			'source_type' => 'db_query',
+			'db_query'    => 'SELECT ID FROM ' . $GLOBALS['wpdb']->prefix . 'posts',
+		);
+
+		try {
+			$this->_handleAjax( 'visualizer-ai-upload' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			// Expected after wp_send_json_error().
+		} finally {
+			remove_filter( 'visualizer_is_pro', '__return_true' );
+		}
+
+		$response = json_decode( $this->_last_response );
+		$this->assertFalse( $response->success );
+		$this->assertSame( 'Action not allowed for this user.', $response->data->message );
+	}
+
+	/**
+	 * Test that a Pro super admin can use the AI Builder database query source.
+	 */
+	public function test_ai_builder_db_query_allows_pro_super_admin() {
+		$this->enable_pro();
+		wp_set_current_user( $this->admin_user_id );
+		$chart_id = $this->factory->post->create(
+			array(
+				'post_type'   => Visualizer_Plugin::CPT_VISUALIZER,
+				'post_status' => 'draft',
+				'post_author' => $this->admin_user_id,
+			)
+		);
+
+		global $wpdb;
+		$_POST = array(
+			'chart_id'    => $chart_id,
+			'nonce'       => wp_create_nonce( 'visualizer-ai-upload-' . $chart_id ),
+			'source_type' => 'db_query',
+			'db_query'    => 'SELECT ID FROM ' . $wpdb->prefix . 'posts WHERE ID = ' . $chart_id,
+		);
+
+		try {
+			$this->_handleAjax( 'visualizer-ai-upload' );
+		} catch ( WPAjaxDieContinueException $e ) {
+			// Expected after wp_send_json_success().
+		} finally {
+			remove_filter( 'visualizer_is_pro', '__return_true' );
+		}
+
+		$response = json_decode( $this->_last_response );
+		$this->assertTrue( $response->success );
+		$this->assertSame( 'Visualizer_Source_Query', get_post_meta( $chart_id, Visualizer_Plugin::CF_SOURCE, true ) );
+	}
+
+	/**
 	 * Test the AJAX response for fetching the database data.
 	 */
 	public function test_ajax_response_get_query_data_valid_query() {


### PR DESCRIPTION
The AI Builder's chart-targeted AJAX handlers used a weaker authorization check than the rest of the plugin — `edit_post` without verifying the target is actually a chart — and the generation-status poller accepted any workflow ID from any logged-in user. This routes every chart-targeted handler through the shared `can_edit_chart()` guard and binds AI workflow IDs to the user who started them. Follow-up to the authorization hardening started in #1348.

### What changed

- **Chart access check** — `_verify_chart_access()` now delegates to `Visualizer_Module::can_edit_chart()`. Before: `current_user_can( 'edit_post', $id )` alone, so any editable post type was accepted — `saveChart` could retitle and force-publish arbitrary posts, and `uploadData` could overwrite non-chart content. After: only `visualizer` posts pass, and contributor-authors keep access to their own charts, matching the rule used by the chart editor endpoints.

- **Workflow status polling** — `generateChart` stores the returned workflow ID in a user-scoped transient; `chartStatus` answers 403 for IDs not bound to the current user. Before: any user with `edit_posts` could poll another user's AI generation and read its full payload (prompt, series, data, generated code).

- **Upload validation** — unchanged. The uploaded file is parsed in place by the CSV/XLSX source classes, which reject content without the required header/type rows, and is never written to a web-accessible path, so the extension check is dispatch logic, not a security boundary. MIME sniffing was left out because real-world CSVs often sniff as `text/plain` and would be rejected.

> [!NOTE]
> `saveChart` keeps the plugin's existing force-publish behavior for charts (same as the classic chart editor save), gated by the same `can_edit_chart()` rule, so contributor-owned AI charts keep working.

### AI Builder request flow

```mermaid
flowchart LR
    A[AI Builder AJAX request] --> B{Nonce valid?}
    B -- no --> X[403]
    B -- yes --> C{Changed:<br/>can_edit_chart<br/>chart_id?}:::changed
    C -- no --> X
    C -- yes --> D{Action}
    D -- generate --> E[Start AI workflow] --> F[New:<br/>bind workflow ID<br/>to user transient]:::added
    D -- poll status --> G{New:<br/>workflow bound<br/>to user?}:::added
    G -- no --> X
    G -- yes --> H[Return status]
    D -- fetch / upload / save --> I[Operate on chart]

    classDef added fill:#1a7f37,color:#fff,stroke:#116329,stroke-width:3px
    classDef changed fill:#9a6700,color:#fff,stroke:#5c3d00,stroke-width:3px,stroke-dasharray:6 3
```

### Data changes

| Key | Value | Lifetime |
|-----|-------|----------|
| `viz_ai_wf_<workflow_id>` transient | ID of the user who started the generation | 6 hours |

Before → after: workflow IDs were unbound → each is bound to its creator for the generation's lifetime.

### QA

1. WP Admin → Users → Add New: create a user with the **Contributor** role, then log in as that user in a private window.

2. WP Admin → Visualizer → Chart Library. In DevTools console, run the following with the ID of a chart owned by admin:

```js
fetch( vizAIBuilder.ajaxUrl, { method: 'POST', body: new URLSearchParams( { action: 'visualizer-ai-fetch', nonce: vizAIBuilder.nonce, chart_id: '<CHART_ID>' } ) } ).then( r => r.json() ).then( console.log );
```

**Expect:** `{ success: false, data: { message: "Unauthorized." } }` with HTTP 403. Before this change, the same request returned the chart's full data payload.

3. Repeat the console call with `action: 'visualizer-ai-status'` and any made-up `workflow_id`.

**Expect:** the same `Unauthorized.` response — before, the request was proxied to the AI service and returned its payload.

4. Regression — as the contributor, WP Admin → Visualizer → Chart Library → Add New → AI Builder, and load data from pasted CSV. Then run the `visualizer-ai-fetch` call from step 2 against the draft chart ID returned by the builder.

**Expect:** the request succeeds — contributors keep full access to charts they created.
