### PR TITLE
fix: gate setup wizard endpoints behind manage_options and nonces

### DIFF
--- a/classes/Visualizer/Module.php
+++ b/classes/Visualizer/Module.php
@@ -650,7 +650,7 @@ class Visualizer_Module {
 				$class_name = $id . $name;
 				$properties = implode( ' !important; ', array_filter( $attributes ) );
 				if ( ! empty( $properties ) ) {
-					$css    .= '.' . $class_name . ' {' . $properties . ' !important;}';
+					$css    .= wp_strip_all_tags( '.' . $class_name . ' {' . $properties . ' !important;}' );
 					$classes[ $name ] = $class_name;
 				}
 			}

--- a/classes/Visualizer/Module/Wizard.php
+++ b/classes/Visualizer/Module/Wizard.php
@@ -153,6 +153,12 @@ class Visualizer_Module_Wizard extends Visualizer_Module {
 	 * @return bool|void
 	 */
 	public function dismissWizard( $redirect_to_dashboard = true ) {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You do not have permission to perform this action.', 'visualizer' ), '', array( 'response' => 403 ) );
+		}
+		if ( false !== $redirect_to_dashboard ) {
+			check_admin_referer( 'visualizer_dismiss_wizard' );
+		}
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$status = isset( $_REQUEST['status'] ) ? (int) $_REQUEST['status'] : 0;
 		update_option( 'visualizer_fresh_install', $status );
@@ -169,6 +175,9 @@ class Visualizer_Module_Wizard extends Visualizer_Module {
 	 */
 	public function visualizer_wizard_step_process() {
 		check_ajax_referer( VISUALIZER_ABSPATH, 'security' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json( array( 'status' => 0 ), 403 );
+		}
 		$step = ! empty( $_POST['step'] ) ? sanitize_text_field( wp_unslash( $_POST['step'] ) ) : 1;
 		switch ( $step ) {
 			case 'step_2':

--- a/templates/setup-wizard.php
+++ b/templates/setup-wizard.php
@@ -6,12 +6,15 @@
  * @package Templates
  */
 
-$dashboard_url = add_query_arg(
-	array(
-		'action' => 'visualizer_dismiss_wizard',
-		'status' => 0,
+$dashboard_url = wp_nonce_url(
+	add_query_arg(
+		array(
+			'action' => 'visualizer_dismiss_wizard',
+			'status' => 0,
+		),
+		admin_url( 'admin.php' )
 	),
-	admin_url( 'admin.php' )
+	'visualizer_dismiss_wizard'
 );
 
 $chart_id           = ! empty( $this->wizard_data['chart_id'] ) ? (int) $this->wizard_data['chart_id'] : '';

--- a/tests/e2e/config/mu-plugins/plant-chart-settings.php
+++ b/tests/e2e/config/mu-plugins/plant-chart-settings.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * E2E test helper (loaded as an mu-plugin via .wp-env.json).
+ *
+ * Lets specs plant chart data/settings meta directly, e.g. a stored-XSS
+ * payload in `customcss` that UI save flows strip on submission, so
+ * render-time sanitization can be verified.
+ */
+add_action(
+	'rest_api_init',
+	function () {
+		register_rest_route(
+			'visualizer-e2e/v1',
+			'/chart-settings/(?P<id>\d+)',
+			array(
+				'methods'             => 'POST',
+				'permission_callback' => function () {
+					return current_user_can( 'manage_options' );
+				},
+				'callback'            => function ( WP_REST_Request $request ) {
+					$chart_id = (int) $request['id'];
+					$body     = $request->get_json_params();
+					if ( isset( $body['settings'] ) ) {
+						update_post_meta( $chart_id, 'visualizer-settings', $body['settings'] );
+					}
+					if ( isset( $body['series'] ) ) {
+						update_post_meta( $chart_id, 'visualizer-series', $body['series'] );
+					}
+					if ( isset( $body['content'] ) ) {
+						wp_update_post(
+							array(
+								'ID'           => $chart_id,
+								'post_content' => maybe_serialize( $body['content'] ),
+							)
+						);
+					}
+					return array( 'ok' => true );
+				},
+			)
+		);
+	}
+);

--- a/tests/e2e/specs/custom-css.spec.js
+++ b/tests/e2e/specs/custom-css.spec.js
@@ -1,0 +1,51 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+let chartId;
+
+test.describe( 'Custom CSS sanitization', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		const chart = await requestUtils.rest( {
+			method: 'POST',
+			path: '/wp/v2/visualizer',
+			data: { title: 'Custom CSS payload chart', status: 'publish' },
+		} );
+		chartId = chart.id;
+
+		await requestUtils.rest( {
+			method: 'POST',
+			path: `/visualizer-e2e/v1/chart-settings/${ chartId }`,
+			data: {
+				settings: {
+					customcss: {
+						title: {
+							color: 'red</style><script>window.vizXss=1</script><style>',
+							'font-size': '12px',
+						},
+					},
+				},
+			},
+		} );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		if ( chartId ) {
+			await requestUtils.rest( { method: 'DELETE', path: `/wp/v2/visualizer/${ chartId }`, params: { force: true } } );
+		}
+	} );
+
+	test( 'strips tags from chart custom CSS on the library page', async ( { admin, page } ) => {
+		await admin.visitAdminPage( 'admin.php?page=visualizer' );
+
+		const styleBlock = page.locator( `#customcss-visualizer-${ chartId }` );
+		await expect( styleBlock ).toHaveCount( 1 );
+		// Legitimate rules survive sanitization. <style> has no innerText, so read textContent.
+		const css = await styleBlock.textContent();
+		expect( css ).toContain( 'font-size: 12px' );
+		expect( css ).not.toContain( '<script' );
+		// The injected script must not have executed.
+		expect( await page.evaluate( () => window.vizXss ) ).toBeUndefined();
+	} );
+} );

--- a/tests/e2e/specs/wizard-auth.spec.js
+++ b/tests/e2e/specs/wizard-auth.spec.js
@@ -1,0 +1,46 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+const CONTRIBUTOR = { username: 'viz_wiz_contributor', password: 'viz-wiz-contributor-pass', email: 'viz-wiz-contributor@example.com' };
+
+let contributorId;
+
+test.describe( 'Setup wizard authorization', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		const contributor = await requestUtils.rest( {
+			method: 'POST',
+			path: '/wp/v2/users',
+			data: { ...CONTRIBUTOR, roles: [ 'contributor' ] },
+		} );
+		contributorId = contributor.id;
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		if ( contributorId ) {
+			await requestUtils.rest( { method: 'DELETE', path: `/wp/v2/users/${ contributorId }`, params: { force: true, reassign: 1 } } );
+		}
+	} );
+
+	test( 'denies wizard dismissal for non-admin users', async ( { browser } ) => {
+		const context = await browser.newContext( { baseURL: test.info().project.use.baseURL } );
+		const page = await context.newPage();
+		await page.goto( '/wp-login.php' );
+		await page.fill( '#user_login', CONTRIBUTOR.username );
+		await page.fill( '#user_pass', CONTRIBUTOR.password );
+		await page.click( '#wp-submit' );
+		await page.waitForURL( '**/wp-admin/**' );
+
+		const response = await page.goto( '/wp-admin/admin.php?action=visualizer_dismiss_wizard&status=1' );
+		expect( response.status() ).toBe( 403 );
+
+		await context.close();
+	} );
+
+	test( 'requires a nonce for wizard dismissal', async ( { page } ) => {
+		// Logged in as admin (default storage state) but without a nonce.
+		const response = await page.goto( '/wp-admin/admin.php?action=visualizer_dismiss_wizard&status=1' );
+		expect( response.status() ).toBe( 403 );
+	} );
+} );

--- a/tests/e2e/specs/wizard-auth.spec.js
+++ b/tests/e2e/specs/wizard-auth.spec.js
@@ -25,13 +25,20 @@ test.describe( 'Setup wizard authorization', () => {
 
 	test( 'denies wizard dismissal for non-admin users', async ( { browser } ) => {
 		const context = await browser.newContext( { baseURL: test.info().project.use.baseURL } );
-		const page = await context.newPage();
-		await page.goto( '/wp-login.php' );
-		await page.fill( '#user_login', CONTRIBUTOR.username );
-		await page.fill( '#user_pass', CONTRIBUTOR.password );
-		await page.click( '#wp-submit' );
-		await page.waitForURL( '**/wp-admin/**' );
+		// POST wp-login with redirects off: the auth cookie is set by the 302
+		// response, so we never load the wp-admin dashboard (can stall in CI).
+		const loginResponse = await context.request.post( '/wp-login.php', {
+			form: {
+				log: CONTRIBUTOR.username,
+				pwd: CONTRIBUTOR.password,
+				'wp-submit': 'Log In',
+				testcookie: '1',
+			},
+			maxRedirects: 0,
+		} );
+		expect( loginResponse.status() ).toBe( 302 );
 
+		const page = await context.newPage();
 		const response = await page.goto( '/wp-admin/admin.php?action=visualizer_dismiss_wizard&status=1' );
 		expect( response.status() ).toBe( 403 );
 


### PR DESCRIPTION
The setup wizard's dismiss action and step-processing endpoint could be invoked by any logged-in user — dismissal without any nonce, and steps with only a nonce — letting low-privilege users flip install state, create charts and draft pages, or trigger plugin installs. This gates the dismiss action behind `manage_options` plus a nonce, and the step dispatcher behind `manage_options`.

### What changed

- **Dismiss action** — `admin.php?action=visualizer_dismiss_wizard` now requires `manage_options` and a valid nonce via `check_admin_referer()`, and the wizard template signs its dismiss link with `wp_nonce_url()`. Before: no nonce and no capability check — any authenticated user could flip the `visualizer_fresh_install` option and wipe `visualizer_wizard_data`.

- **Step dispatcher** — `visualizer_wizard_step_process` rejects non-admins with 403 after the existing nonce check. One gate covers every step: chart import, plugin install, subscribe, and draft-page creation (which also deletes all post meta of the page it updates).

> [!NOTE]
> The internal `dismissWizard( false )` call from the subscribe step intentionally skips `check_admin_referer()` — it is only reachable through the step dispatcher, which is already nonce- and capability-verified.

### Wizard request flow

```mermaid
flowchart LR
    A[Wizard request] --> B{Entry point}
    B -- dismiss link --> C{Changed:<br/>manage_options?}:::changed
    B -- step AJAX --> D{Nonce valid?}
    C -- no --> X[403]
    C -- yes --> E{New:<br/>nonce valid?}:::added
    E -- no --> X
    E -- yes --> F[Update options, redirect]
    D -- no --> X
    D -- yes --> G{New:<br/>manage_options?}:::added
    G -- no --> X
    G -- yes --> H[Run wizard step]

    classDef added fill:#1a7f37,color:#fff,stroke:#116329,stroke-width:3px
    classDef changed fill:#9a6700,color:#fff,stroke:#5c3d00,stroke-width:3px,stroke-dasharray:6 3
```

### QA

1. WP Admin → Users → Add New: create a **Contributor** user and log in as them in a private window.

2. As the contributor, visit `/wp-admin/admin.php?action=visualizer_dismiss_wizard&status=1`.

**Expect:** a 403 "You do not have permission to perform this action." page. Before this change, the same URL silently updated the option and redirected to the Visualizer dashboard.

3. As **admin**, visit the same URL without a nonce.

**Expect:** the "link you followed has expired" nonce screen (403). Before, it dismissed the wizard.

4. Regression — on a fresh install (or after `wp option update visualizer_fresh_install 1`), open WP Admin → Visualizer and complete the setup wizard, using the skip/dismiss link at the end.

**Expect:** the wizard completes and dismisses normally and the Chart Library loads.
