### PR TITLE
fix: strip tags from chart custom CSS at render time

### DIFF
--- a/classes/Visualizer/Module.php
+++ b/classes/Visualizer/Module.php
@@ -650,7 +650,7 @@ class Visualizer_Module {
 				$class_name = $id . $name;
 				$properties = implode( ' !important; ', array_filter( $attributes ) );
 				if ( ! empty( $properties ) ) {
-					$css    .= '.' . $class_name . ' {' . $properties . ' !important;}';
+					$css    .= wp_strip_all_tags( '.' . $class_name . ' {' . $properties . ' !important;}' );
 					$classes[ $name ] = $class_name;
 				}
 			}

--- a/tests/e2e/config/mu-plugins/plant-chart-settings.php
+++ b/tests/e2e/config/mu-plugins/plant-chart-settings.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * E2E test helper (loaded as an mu-plugin via .wp-env.json).
+ *
+ * Lets specs plant chart data/settings meta directly, e.g. a stored-XSS
+ * payload in `customcss` that UI save flows strip on submission, so
+ * render-time sanitization can be verified.
+ */
+add_action(
+	'rest_api_init',
+	function () {
+		register_rest_route(
+			'visualizer-e2e/v1',
+			'/chart-settings/(?P<id>\d+)',
+			array(
+				'methods'             => 'POST',
+				'permission_callback' => function () {
+					return current_user_can( 'manage_options' );
+				},
+				'callback'            => function ( WP_REST_Request $request ) {
+					$chart_id = (int) $request['id'];
+					$body     = $request->get_json_params();
+					if ( isset( $body['settings'] ) ) {
+						update_post_meta( $chart_id, 'visualizer-settings', $body['settings'] );
+					}
+					if ( isset( $body['series'] ) ) {
+						update_post_meta( $chart_id, 'visualizer-series', $body['series'] );
+					}
+					if ( isset( $body['content'] ) ) {
+						wp_update_post(
+							array(
+								'ID'           => $chart_id,
+								'post_content' => maybe_serialize( $body['content'] ),
+							)
+						);
+					}
+					return array( 'ok' => true );
+				},
+			)
+		);
+	}
+);

--- a/tests/e2e/specs/custom-css.spec.js
+++ b/tests/e2e/specs/custom-css.spec.js
@@ -41,8 +41,10 @@ test.describe( 'Custom CSS sanitization', () => {
 
 		const styleBlock = page.locator( `#customcss-visualizer-${ chartId }` );
 		await expect( styleBlock ).toHaveCount( 1 );
-		// Legitimate rules survive sanitization.
-		await expect( styleBlock ).toContainText( 'font-size: 12px' );
+		// Legitimate rules survive sanitization. <style> has no innerText, so read textContent.
+		const css = await styleBlock.textContent();
+		expect( css ).toContain( 'font-size: 12px' );
+		expect( css ).not.toContain( '<script' );
 		// The injected script must not have executed.
 		expect( await page.evaluate( () => window.vizXss ) ).toBeUndefined();
 	} );

--- a/tests/e2e/specs/custom-css.spec.js
+++ b/tests/e2e/specs/custom-css.spec.js
@@ -1,0 +1,49 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+let chartId;
+
+test.describe( 'Custom CSS sanitization', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		const chart = await requestUtils.rest( {
+			method: 'POST',
+			path: '/wp/v2/visualizer',
+			data: { title: 'Custom CSS payload chart', status: 'publish' },
+		} );
+		chartId = chart.id;
+
+		await requestUtils.rest( {
+			method: 'POST',
+			path: `/visualizer-e2e/v1/chart-settings/${ chartId }`,
+			data: {
+				settings: {
+					customcss: {
+						title: {
+							color: 'red</style><script>window.vizXss=1</script><style>',
+							'font-size': '12px',
+						},
+					},
+				},
+			},
+		} );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		if ( chartId ) {
+			await requestUtils.rest( { method: 'DELETE', path: `/wp/v2/visualizer/${ chartId }`, params: { force: true } } );
+		}
+	} );
+
+	test( 'strips tags from chart custom CSS on the library page', async ( { admin, page } ) => {
+		await admin.visitAdminPage( 'admin.php?page=visualizer' );
+
+		const styleBlock = page.locator( `#customcss-visualizer-${ chartId }` );
+		await expect( styleBlock ).toHaveCount( 1 );
+		// Legitimate rules survive sanitization.
+		await expect( styleBlock ).toContainText( 'font-size: 12px' );
+		// The injected script must not have executed.
+		expect( await page.evaluate( () => window.vizXss ) ).toBeUndefined();
+	} );
+} );


### PR DESCRIPTION
Chart authors control the `customcss` chart setting, and its contents were concatenated into a `<style>` block echoed without escaping on every page that renders chart CSS — including the admin Chart Library that aggregates CSS from all charts. This strips tags from each generated rule block at the single point where the CSS is built.

### What changed

- **CSS builder** — `get_inline_custom_css()` now passes each chart's generated rule block through `wp_strip_all_tags()`. Before: a `customcss` value containing `</style><script>…</script>` broke out of the style element and executed for anyone viewing WP Admin → Visualizer → Chart Library (admins) or a frontend page embedding the chart (visitors). After: markup is removed, legitimate declarations pass through untouched.

- **Coverage** — fixing at the builder covers all four sinks at once: Chart Library, chart editor data page, chart iframe render, and the frontend render.

> [!NOTE]
> `wp_strip_all_tags()` removes anything tag-shaped, so CSS values can no longer contain literal tag-like strings (e.g. in `content:`) — these never occur in the plugin's custom-CSS fields. Pure CSS-level injection (e.g. `url()` references) is out of scope; this closes the script-injection vector.

### QA

1. Plant a payload on any published chart (UI save flows strip tags, so use wp-cli):

```bash
wp eval 'update_post_meta( <CHART_ID>, "visualizer-settings", array( "customcss" => array( "title" => array( "color" => "red</style><script>alert(1)</script><style>", "font-size" => "12px" ) ) ) );'
```

2. WP Admin → Visualizer → Chart Library.

**Expect:** no alert fires. In DevTools, the chart's `<style id="customcss-visualizer-<CHART_ID>">` block contains only CSS declarations (`font-size: 12px !important;` is still present).

3. Regression — open a chart that uses legitimate custom CSS in WP Admin → Visualizer → Chart Library → edit chart, and on a frontend page containing its shortcode.

**Expect:** custom styles still apply in both places.
