### PR TITLE
fix: gate AI Builder db_query behind super-admin + Pro to match classic path

### DIFF
--- a/classes/Visualizer/Module/AIBuilder.php
+++ b/classes/Visualizer/Module/AIBuilder.php
@@ -369,7 +369,7 @@ class Visualizer_Module_AIBuilder extends Visualizer_Module {
 
 			// ── Database query ────────────────────────────────────────────────
 			case 'db_query':
-				if ( ! current_user_can( 'manage_options' ) && ! is_super_admin() ) {
+				if ( ! current_user_can( 'manage_options' ) || ! is_super_admin() || ! Visualizer_Module::is_pro() ) {
 					wp_send_json_error( array( 'message' => __( 'Action not allowed for this user.', 'visualizer' ) ), 403 );
 				}
 				if ( empty( $_POST['db_query'] ) ) {


### PR DESCRIPTION
The AI Builder's `db_query` upload branch runs an operator-supplied SQL `SELECT` through `Visualizer_Source_Query` — the same sink as the classic `Visualizer_Module_Chart::getQueryData()` / `saveQuery()` handlers. Those classic handlers gate the feature on administrator **and** super-admin **and** an active Pro license; the AI Builder branch did not match that gate. This aligns them.

The earlier fix ([visualizer-pro#587](https://github.com/Codeinwp/visualizer-pro/issues/587), PR #1313) added a capability check here, but it was both weaker and incomplete: the two conditions were combined with `&&` (so the request was blocked only when the user had *neither* capability), and the Pro-feature check was missing entirely. Patchstack flagged the fix as not fully closing the report for this reason.

## What changed

- **`db_query` gate** — now denies the request unless the user has `manage_options` **and** `is_super_admin()` **and** the site is running Visualizer Pro, matching the classic DB-query handlers exactly. Before: `! manage_options && ! is_super_admin` (passed for anyone holding either cap, and ignored Pro). After: `! manage_options || ! is_super_admin || ! is_pro`.

> [!NOTE]
> A super-admin on a Pro site running their own `SELECT` is intended feature behavior (the "Import from database" data source), unchanged here. This PR only restores the trust boundary that already governs the classic path — it does not alter what an authorized admin can do.

## db_query authorization

```mermaid
flowchart LR
    A[visualizer-ai-upload<br/>source_type=db_query] --> B{Nonce valid?}
    B -- No --> X[403]
    B -- Yes --> C{Changed:<br/>manage_options AND<br/>super-admin AND Pro?}:::changed
    C -- No --> X
    C -- Yes --> D[Run SELECT via<br/>Visualizer_Source_Query]

    classDef changed fill:#9a6700,color:#fff,stroke:#5c3d00,stroke-width:3px,stroke-dasharray:6 3
```

## QA

1. WP Admin → Users → Add New: create a **Contributor**, log in as them in a private window.

2. WP Admin → Visualizer → Chart Library, open DevTools console, and create a draft chart to obtain an upload nonce:
   ```js
   const create = await fetch( ajaxurl, { method: 'POST', body: new URLSearchParams( { action: 'visualizer-ai-create', nonce: vizAIBuilder.nonce } ) } ).then( r => r.json() );
   const { chart_id, upload_nonce } = create.data;
   ```
   Then attempt the DB query against it:
   ```js
   await fetch( ajaxurl, { method: 'POST', body: new URLSearchParams( { action: 'visualizer-ai-upload', nonce: upload_nonce, chart_id, source_type: 'db_query', db_query: 'SELECT user_login,user_pass FROM wp_users WHERE ID=1' } ) } ).then( r => r.json() );
   ```
   **Expect:** `{ success: false, data: { message: "Action not allowed for this user." } }` — no query result returned.

3. On a **non-Pro** site, repeat step 2 logged in as an **Administrator**.
   **Expect:** the same `Action not allowed for this user.` response — the feature is Pro-only, matching the classic DB-query handlers.

4. On a **Pro** site, as a super-admin, use Visualizer → Add New → AI Builder → load data from a database query.
   **Expect:** the query runs and the chart populates — the intended feature is unaffected.

---

Follow-up to PR #1313. Related: [visualizer-pro#587](https://github.com/Codeinwp/visualizer-pro/issues/587), [HelpScout 3311008102](https://secure.helpscout.net/conversation/3311008102/488920).
