### PR TITLE
fix: keep usage logger alive when chart settings meta is not an array

### DIFF
--- a/classes/Visualizer/Module/Admin.php
+++ b/classes/Visualizer/Module/Admin.php
@@ -81,7 +81,6 @@ class Visualizer_Module_Admin extends Visualizer_Module {
 		$this->_addFilter( 'media_view_strings', 'setupMediaViewStrings' );
 		$this->_addFilter( 'plugin_action_links', 'getPluginActionLinks', 10, 2 );
 		$this->_addFilter( 'plugin_row_meta', 'getPluginMetaLinks', 10, 2 );
-		$this->_addFilter( 'visualizer_logger_data', 'getLoggerData' );
 		$this->_addFilter( 'visualizer_feedback_review_trigger', 'feedbackReviewTrigger' );
 		$this->_addFilter( 'themeisle_sdk_blackfriday_data', 'add_black_friday_data' );
 

--- a/classes/Visualizer/Module/Setup.php
+++ b/classes/Visualizer/Module/Setup.php
@@ -124,7 +124,7 @@ class Visualizer_Module_Setup extends Visualizer_Module {
 
 			if ( Visualizer_Module::is_pro() ) {
 				$permissions = get_post_meta( $chart_id, Visualizer_Pro::CF_PERMISSIONS, true );
-				if ( ! is_array( $permissions ) || empty( $permissions['permissions'] ) ) {
+				if ( ! is_array( $permissions ) || empty( $permissions['permissions'] ) || ! is_array( $permissions['permissions'] ) ) {
 					continue;
 				}
 				$permissions = $permissions['permissions'];

--- a/classes/Visualizer/Module/Setup.php
+++ b/classes/Visualizer/Module/Setup.php
@@ -113,7 +113,7 @@ class Visualizer_Module_Setup extends Visualizer_Module {
 			$lib     = get_post_meta( $chart_id, Visualizer_Plugin::CF_CHART_LIBRARY, true );
 			$charts['library'][ $lib ]    = isset( $charts['library'][ $lib ] ) ? $charts['library'][ $lib ] + 1 : 1;
 			$settings       = get_post_meta( $chart_id, Visualizer_Plugin::CF_SETTINGS, true );
-			if ( array_key_exists( 'manual', $settings ) && ! empty( $settings['manual'] ) ) {
+			if ( is_array( $settings ) && ! empty( $settings['manual'] ) ) {
 				$charts['manual_config']    = $charts['manual_config'] + 1;
 			}
 
@@ -124,7 +124,7 @@ class Visualizer_Module_Setup extends Visualizer_Module {
 
 			if ( Visualizer_Module::is_pro() ) {
 				$permissions = get_post_meta( $chart_id, Visualizer_Pro::CF_PERMISSIONS, true );
-				if ( empty( $permissions ) ) {
+				if ( ! is_array( $permissions ) || empty( $permissions['permissions'] ) ) {
 					continue;
 				}
 				$permissions = $permissions['permissions'];

--- a/classes/Visualizer/Module/Setup.php
+++ b/classes/Visualizer/Module/Setup.php
@@ -132,7 +132,7 @@ class Visualizer_Module_Setup extends Visualizer_Module {
 				foreach ( $default_perms as $key => $val ) {
 					if ( ! is_array( $val ) && ! is_null( $val ) && isset( $permissions[ $key ] ) && $permissions[ $key ] !== $val ) {
 						$customized = true;
-					} elseif ( is_array( $val ) && ! is_null( $val ) && isset( $permissions[ $key ] ) && count( $permissions[ $key ] ) !== count( $val ) ) {
+					} elseif ( is_array( $val ) && ! is_null( $val ) && isset( $permissions[ $key ] ) && is_array( $permissions[ $key ] ) && count( $permissions[ $key ] ) !== count( $val ) ) {
 						$customized = true;
 					}
 				}

--- a/tests/e2e/config/mu-plugins/plant-chart-settings.php
+++ b/tests/e2e/config/mu-plugins/plant-chart-settings.php
@@ -38,5 +38,21 @@ add_action(
 				},
 			)
 		);
+
+		// Runs the SDK usage logger on demand, so specs can verify it
+		// tolerates whatever chart meta they planted (issue #1359).
+		register_rest_route(
+			'visualizer-e2e/v1',
+			'/usage',
+			array(
+				'methods'             => 'GET',
+				'permission_callback' => function () {
+					return current_user_can( 'manage_options' );
+				},
+				'callback'            => function () {
+					return apply_filters( 'visualizer_logger_data', array() );
+				},
+			)
+		);
 	}
 );

--- a/tests/e2e/specs/usage-logger.spec.js
+++ b/tests/e2e/specs/usage-logger.spec.js
@@ -1,0 +1,61 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+/**
+ * Regression tests for https://github.com/Codeinwp/visualizer/issues/1359
+ *
+ * A published chart whose `visualizer-settings` meta is a string (instead of
+ * the sanitized settings array) crashed `Visualizer_Module_Setup::getUsage()`
+ * with a PHP 8 TypeError, aborting the whole SDK usage collection request.
+ * The logger must tolerate such charts and still report the others.
+ */
+test.describe( 'Usage logger', () => {
+	let corruptedId;
+	let manualId;
+
+	test.beforeAll( async ( { requestUtils } ) => {
+		// A chart whose settings meta is a corrupted string value.
+		const corrupted = await requestUtils.rest( {
+			method: 'POST',
+			path: '/wp/v2/visualizer',
+			data: { title: 'Corrupted settings chart', status: 'publish' },
+		} );
+		corruptedId = corrupted.id;
+		await requestUtils.rest( {
+			method: 'POST',
+			path: `/visualizer-e2e/v1/chart-settings/${ corruptedId }`,
+			data: { settings: 'corrupted string settings' },
+		} );
+
+		// A healthy chart with a manual configuration, which must still be counted.
+		const manual = await requestUtils.rest( {
+			method: 'POST',
+			path: '/wp/v2/visualizer',
+			data: { title: 'Manual config chart', status: 'publish' },
+		} );
+		manualId = manual.id;
+		await requestUtils.rest( {
+			method: 'POST',
+			path: `/visualizer-e2e/v1/chart-settings/${ manualId }`,
+			data: { settings: { manual: '{"colors": ["#000"]}' } },
+		} );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		for ( const id of [ corruptedId, manualId ] ) {
+			if ( id ) {
+				await requestUtils.rest( { method: 'DELETE', path: `/wp/v2/visualizer/${ id }`, params: { force: true } } );
+			}
+		}
+	} );
+
+	test( 'survives a chart whose settings meta is a string', async ( { requestUtils } ) => {
+		// Before the fix this request died with a TypeError (HTTP 500).
+		const usage = await requestUtils.rest( { method: 'GET', path: '/visualizer-e2e/v1/usage' } );
+
+		expect( usage.manual_config ).toBe( 1 );
+		expect( Object.values( usage.types ).reduce( ( a, b ) => a + b, 0 ) ).toBe( 2 );
+	} );
+} );

--- a/tests/e2e/specs/usage-logger.spec.js
+++ b/tests/e2e/specs/usage-logger.spec.js
@@ -4,6 +4,11 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 /**
+ * Internal dependencies
+ */
+const { deleteAllCharts } = require( '../utils/common' );
+
+/**
  * Regression tests for https://github.com/Codeinwp/visualizer/issues/1359
  *
  * A published chart whose `visualizer-settings` meta is a string (instead of
@@ -16,6 +21,9 @@ test.describe( 'Usage logger', () => {
 	let manualId;
 
 	test.beforeAll( async ( { requestUtils } ) => {
+		// The assertions below count charts, so start from a clean library.
+		await deleteAllCharts( requestUtils );
+
 		// A chart whose settings meta is a corrupted string value.
 		const corrupted = await requestUtils.rest( {
 			method: 'POST',

--- a/tests/test-usage-logger.php
+++ b/tests/test-usage-logger.php
@@ -62,6 +62,33 @@ class Test_Visualizer_Usage_Logger extends WP_UnitTestCase {
 	}
 
 	/**
+	 * On pro, a permission entry that should be an array but is a string
+	 * must not abort usage collection with a count() TypeError.
+	 */
+	public function test_malformed_permissions_meta_does_not_crash_logger() {
+		// The stub stays defined for the rest of the PHPUnit process. That only
+		// affects code gating on class_exists( 'Visualizer_Pro' ) — the legacy
+		// license fallback in proFeaturesEnabled() — which no test exercises.
+		if ( ! class_exists( 'Visualizer_Pro' ) ) {
+			eval( 'class Visualizer_Pro { const CF_PERMISSIONS = "visualizer-permissions"; }' );
+		}
+
+		$chart_id = $this->create_chart( array() );
+		update_post_meta(
+			$chart_id,
+			Visualizer_Pro::CF_PERMISSIONS,
+			array( 'permissions' => array( 'edit-specific' => 'administrator' ) )
+		);
+
+		add_filter( 'visualizer_is_pro', '__return_true' );
+		$usage = apply_filters( 'visualizer_logger_data', array() );
+		remove_filter( 'visualizer_is_pro', '__return_true' );
+
+		$this->assertIsArray( $usage );
+		$this->assertSame( 0, $usage['permissions'] );
+	}
+
+	/**
 	 * Valid array settings still count manual configurations.
 	 */
 	public function test_manual_config_still_counted_for_array_settings() {

--- a/tests/test-usage-logger.php
+++ b/tests/test-usage-logger.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * WordPress unit test plugin.
+ *
+ * @package     visualizer
+ * @subpackage  Tests
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ */
+
+/**
+ * Test the usage logger fed to the Themeisle SDK.
+ *
+ * Regression tests for https://github.com/Codeinwp/visualizer/issues/1359 —
+ * a published chart whose `visualizer-settings` meta is a string crashed
+ * `Visualizer_Module_Setup::getUsage()` with a TypeError on PHP 8, aborting
+ * scheduled usage collection.
+ */
+class Test_Visualizer_Usage_Logger extends WP_UnitTestCase {
+
+	/**
+	 * Create a published chart with the given settings meta value.
+	 *
+	 * @param mixed $settings The value stored in the visualizer-settings meta.
+	 * @return int The chart id.
+	 */
+	private function create_chart( $settings ) {
+		$chart_id = self::factory()->post->create(
+			array(
+				'post_type'    => Visualizer_Plugin::CPT_VISUALIZER,
+				'post_status'  => 'publish',
+				'post_content' => wp_slash( serialize( array( array( 'Label' ), array( 'Value' ) ) ) ),
+			)
+		);
+		update_post_meta( $chart_id, Visualizer_Plugin::CF_CHART_TYPE, 'line' );
+		update_post_meta( $chart_id, Visualizer_Plugin::CF_SETTINGS, $settings );
+		return $chart_id;
+	}
+
+	/**
+	 * A chart whose settings meta is a string must not abort usage collection.
+	 */
+	public function test_string_settings_meta_does_not_crash_logger() {
+		$this->create_chart( 'corrupted string settings' );
+
+		$usage = apply_filters( 'visualizer_logger_data', array() );
+
+		$this->assertIsArray( $usage );
+		$this->assertSame( 0, $usage['manual_config'] );
+	}
+
+	/**
+	 * A chart with no settings meta at all must not abort usage collection.
+	 */
+	public function test_missing_settings_meta_does_not_crash_logger() {
+		$chart_id = $this->create_chart( array() );
+		delete_post_meta( $chart_id, Visualizer_Plugin::CF_SETTINGS );
+
+		$usage = apply_filters( 'visualizer_logger_data', array() );
+
+		$this->assertIsArray( $usage );
+		$this->assertSame( 0, $usage['manual_config'] );
+	}
+
+	/**
+	 * Valid array settings still count manual configurations.
+	 */
+	public function test_manual_config_still_counted_for_array_settings() {
+		$this->create_chart( array( 'manual' => '{"colors": ["#000"]}' ) );
+		$this->create_chart( 'corrupted string settings' );
+
+		$usage = apply_filters( 'visualizer_logger_data', array() );
+
+		$this->assertSame( 1, $usage['manual_config'] );
+		$this->assertSame( 2, $usage['types']['line'] );
+	}
+}

--- a/tests/test-usage-logger.php
+++ b/tests/test-usage-logger.php
@@ -62,8 +62,9 @@ class Test_Visualizer_Usage_Logger extends WP_UnitTestCase {
 	}
 
 	/**
-	 * On pro, a permission entry that should be an array but is a string
-	 * must not abort usage collection with a count() TypeError.
+	 * On pro, permission meta that is not shaped like a map of arrays must not
+	 * abort usage collection — a string entry fatals on count(), and a nested
+	 * object fatals on the array offset read.
 	 */
 	public function test_malformed_permissions_meta_does_not_crash_logger() {
 		// The stub stays defined for the rest of the PHPUnit process. That only
@@ -79,6 +80,9 @@ class Test_Visualizer_Usage_Logger extends WP_UnitTestCase {
 			Visualizer_Pro::CF_PERMISSIONS,
 			array( 'permissions' => array( 'edit-specific' => 'administrator' ) )
 		);
+
+		$object_chart_id = $this->create_chart( array() );
+		update_post_meta( $object_chart_id, Visualizer_Pro::CF_PERMISSIONS, array( 'permissions' => new stdClass() ) );
 
 		add_filter( 'visualizer_is_pro', '__return_true' );
 		$usage = apply_filters( 'visualizer_logger_data', array() );


### PR DESCRIPTION
Scheduled usage telemetry died with `TypeError: array_key_exists(): Argument #2 ($array) must be of type array, string given` whenever a site had one published chart whose `visualizer-settings` post meta is a string instead of the sanitized settings array — one bad chart record aborted the whole SDK usage collection request (three production sites hit this on PHP 8.2/8.3). The logger now tolerates malformed chart meta and still reports every healthy chart.

## What changed

- **`Visualizer_Module_Setup::getUsage()`** — the `manual_config` counter reads the settings meta through an `is_array()` guard. Before → a string (or a chart with no settings meta at all, where `get_post_meta()` returns `''`) threw an uncaught TypeError on PHP 8; after → the chart is skipped for that statistic and collection completes.

- **`Visualizer_Module_Setup::getUsage()` (pro path)** — the `permissions` meta read had the same shape (`$permissions['permissions']` on an unvalidated meta value), so it gets the same `is_array()` guard.

- **`Visualizer_Module_Admin`** — removed its `visualizer_logger_data` registration: it points to a `getLoggerData` method that class does not have, so once the first crash is fixed the filter fatals again with *"class Visualizer_Module_Admin does not have a method getLoggerData"*. The working callback in `Visualizer_Module_Setup` is unchanged.

> [!NOTE]
> How the affected sites acquired string-valued settings meta is unknown (the issue's telemetry couldn't tell). The fix deliberately hardens the reader instead of chasing the writer: the logger must never let one bad record kill the whole collection request.

## Usage collection flow

```mermaid
flowchart LR
    A[SDK cron:<br/>visualizer_logger_data] --> B[Setup::getUsage<br/>loops published charts]
    B --> C{Changed:<br/>settings meta<br/>is an array?}:::changed
    C -- Yes --> D[Count manual_config]
    C -- No --> E[Skip statistic,<br/>keep looping]
    D --> F[Usage payload returned]
    E --> F
    A -.-> G[New: dangling Admin<br/>callback removed]:::added

    classDef added fill:#1a7f37,color:#fff,stroke:#116329,stroke-width:3px
    classDef changed fill:#9a6700,color:#fff,stroke:#5c3d00,stroke-width:3px,stroke-dasharray:6 3
```

## QA

1. Create any chart (WP Admin → Visualizer → Add New Chart, complete the wizard) and corrupt its settings meta with WP-CLI, replacing `<chart_id>` with the chart's post ID:

   ```
   wp post meta update <chart_id> visualizer-settings "corrupted string"
   ```

2. Trigger the logger on PHP 8.2+:

   ```
   wp eval 'var_export( apply_filters( "visualizer_logger_data", array() ) );'
   ```

   **Expect:** a usage array is printed (`types`, `sources`, `manual_config`, …) with no TypeError. On 4.0.7 the same command dies with the `array_key_exists()` TypeError from the crash report.

Fixes #1359
