### PR TITLE
Sanitized JSON data source headers to prevent XSS vulnerabilities

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,6 +1,6 @@
 {
   "core": null,
-  "phpVersion": "7.4",
+  "phpVersion": "8.1",
   "plugins": [
     "."
   ],

--- a/classes/Visualizer/Gutenberg/Block.php
+++ b/classes/Visualizer/Gutenberg/Block.php
@@ -314,6 +314,9 @@ class Visualizer_Gutenberg_Block {
 
 		// faetch and update settings
 		$data['visualizer-settings'] = get_post_meta( $post_id, Visualizer_Plugin::CF_SETTINGS, true );
+		if ( ! is_array( $data['visualizer-settings'] ) ) {
+			$data['visualizer-settings'] = array();
+		}
 		if ( empty( $data['visualizer-settings']['pagination'] ) ) {
 			$data['visualizer-settings']['pageSize'] = '';
 		}

--- a/classes/Visualizer/Module/Chart.php
+++ b/classes/Visualizer/Module/Chart.php
@@ -254,7 +254,7 @@ class Visualizer_Module_Chart extends Visualizer_Module {
 		update_post_meta( $chart->ID, Visualizer_Plugin::CF_SOURCE, $source->getSourceName() );
 		update_post_meta( $chart->ID, Visualizer_Plugin::CF_DEFAULT_DATA, 0 );
 		update_post_meta( $chart->ID, Visualizer_Plugin::CF_JSON_URL, $params['url'] );
-		update_post_meta( $chart->ID, Visualizer_Plugin::CF_JSON_ROOT, sanitize_text_field( $params['root'] ) );
+		update_post_meta( $chart->ID, Visualizer_Plugin::CF_JSON_ROOT, $params['root'] );
 
 		delete_post_meta( $chart->ID, Visualizer_Plugin::CF_JSON_HEADERS );
 		$headers = array( 'method' => $params['method'] );
@@ -264,7 +264,7 @@ class Visualizer_Module_Chart extends Visualizer_Module {
 			$headers['auth'] = array( 'username' => $params['username'], 'password' => $params['password'] );
 		}
 
-		add_post_meta( $chart->ID, Visualizer_Plugin::CF_JSON_HEADERS, $this->sanitizeJsonHeaders( $headers ) );
+		add_post_meta( $chart->ID, Visualizer_Plugin::CF_JSON_HEADERS, $headers );
 
 		delete_post_meta( $chart->ID, Visualizer_Plugin::CF_JSON_PAGING );
 		if ( ! empty( $params['paging'] ) ) {
@@ -1032,16 +1032,6 @@ class Visualizer_Module_Chart extends Visualizer_Module {
 		wp_enqueue_style( 'visualizer-frame' );
 		wp_enqueue_script( 'visualizer-frame' );
 		wp_iframe( array( $render, 'render' ) );
-	}
-
-	/**
-	 * Sanitize the JSON data source headers before they are stored.
-	 *
-	 * @param array<string, mixed> $headers The JSON data source headers.
-	 * @return array<string, mixed> The sanitized headers.
-	 */
-	private function sanitizeJsonHeaders( array $headers ): array {
-		return map_deep( $headers, 'sanitize_text_field' );
 	}
 
 	/**

--- a/classes/Visualizer/Module/Chart.php
+++ b/classes/Visualizer/Module/Chart.php
@@ -254,7 +254,7 @@ class Visualizer_Module_Chart extends Visualizer_Module {
 		update_post_meta( $chart->ID, Visualizer_Plugin::CF_SOURCE, $source->getSourceName() );
 		update_post_meta( $chart->ID, Visualizer_Plugin::CF_DEFAULT_DATA, 0 );
 		update_post_meta( $chart->ID, Visualizer_Plugin::CF_JSON_URL, $params['url'] );
-		update_post_meta( $chart->ID, Visualizer_Plugin::CF_JSON_ROOT, $params['root'] );
+		update_post_meta( $chart->ID, Visualizer_Plugin::CF_JSON_ROOT, sanitize_text_field( $params['root'] ) );
 
 		delete_post_meta( $chart->ID, Visualizer_Plugin::CF_JSON_HEADERS );
 		$headers = array( 'method' => $params['method'] );
@@ -264,7 +264,7 @@ class Visualizer_Module_Chart extends Visualizer_Module {
 			$headers['auth'] = array( 'username' => $params['username'], 'password' => $params['password'] );
 		}
 
-		add_post_meta( $chart->ID, Visualizer_Plugin::CF_JSON_HEADERS, $headers );
+		add_post_meta( $chart->ID, Visualizer_Plugin::CF_JSON_HEADERS, $this->sanitizeJsonHeaders( $headers ) );
 
 		delete_post_meta( $chart->ID, Visualizer_Plugin::CF_JSON_PAGING );
 		if ( ! empty( $params['paging'] ) ) {
@@ -1032,6 +1032,16 @@ class Visualizer_Module_Chart extends Visualizer_Module {
 		wp_enqueue_style( 'visualizer-frame' );
 		wp_enqueue_script( 'visualizer-frame' );
 		wp_iframe( array( $render, 'render' ) );
+	}
+
+	/**
+	 * Sanitize the JSON data source headers before they are stored.
+	 *
+	 * @param array<string, mixed> $headers The JSON data source headers.
+	 * @return array<string, mixed> The sanitized headers.
+	 */
+	private function sanitizeJsonHeaders( array $headers ): array {
+		return map_deep( $headers, 'sanitize_text_field' );
 	}
 
 	/**

--- a/classes/Visualizer/Render/Layout.php
+++ b/classes/Visualizer/Render/Layout.php
@@ -188,8 +188,13 @@ ORDER BY YEAR(post_date) DESC, MONTH(post_date) DESC;';
 		}
 		$methods = apply_filters( 'visualizer_json_request_methods', array( 'GET', 'POST' ) );
 
+		$auth          = isset( $headers['auth'] ) ? $headers['auth'] : '';
+		$auth_username = is_array( $auth ) && isset( $auth['username'] ) ? $auth['username'] : '';
+		$auth_password = is_array( $auth ) && isset( $auth['password'] ) ? $auth['password'] : '';
+		$auth_string   = is_string( $auth ) ? $auth : '';
+
 		// open the headers by default?
-		$headers_open = $headers && array_key_exists( 'auth', $headers ) && ( array_key_exists( 'username', $headers['auth'] ) && ! empty( $headers['auth']['username'] ) ) || ( ! empty( $headers['auth'] ) && is_string( $headers['auth'] ) );
+		$headers_open = ! empty( $auth_username ) || ! empty( $auth_string );
 		?>
 		<div id="visualizer-json-screen" style="display: none">
 			<div class="visualizer-json-form">
@@ -242,7 +247,7 @@ ORDER BY YEAR(post_date) DESC, MONTH(post_date) DESC;';
 											type="text"
 											id="vz-import-json-username"
 											name="username"
-											value="<?php echo ( array_key_exists( 'auth', $headers ) && array_key_exists( 'username', $headers['auth'] ) ? $headers['auth']['username'] : '' ); ?>"
+											value="<?php echo esc_attr( $auth_username ); ?>"
 											placeholder="<?php esc_html_e( 'Username/Access Key', 'visualizer' ); ?>"
 											class="json-form-element">
 										&
@@ -250,7 +255,7 @@ ORDER BY YEAR(post_date) DESC, MONTH(post_date) DESC;';
 											type="password"
 											id="vz-import-json-password"
 											name="password"
-											value="<?php echo ( array_key_exists( 'auth', $headers ) && array_key_exists( 'password', $headers['auth'] ) ? $headers['auth']['password'] : '' ); ?>"
+											value="<?php echo esc_attr( $auth_password ); ?>"
 											placeholder="<?php esc_html_e( 'Password/Secret Key', 'visualizer' ); ?>"
 											class="json-form-element">
 									</div>
@@ -266,7 +271,7 @@ ORDER BY YEAR(post_date) DESC, MONTH(post_date) DESC;';
 											type="text"
 											id="vz-import-json-auth"
 											name="auth"
-											value="<?php echo ( array_key_exists( 'auth', $headers ) && is_string( $headers['auth'] ) ? $headers['auth'] : '' ); ?>"
+											value="<?php echo esc_attr( $auth_string ); ?>"
 											placeholder="<?php esc_html_e( 'e.g. SharedKey <AccountName>:<Signature>', 'visualizer' ); ?>"
 											class="visualizer-input json-form-element">
 									</div>
@@ -274,7 +279,7 @@ ORDER BY YEAR(post_date) DESC, MONTH(post_date) DESC;';
 								<div class="json-wizard-header">
 									<div class="field-title"><?php esc_html_e( 'Additional headers', 'visualizer' ); ?></div>
 									<div>
-										<textarea name="additional_headers" class="visualizer-input" placeholder="<?php esc_html_e( 'Key:Value, Key2:Value2,...', 'visualizer' ); ?>"><?php echo isset( $headers['additional_headers'] ) ? $headers['additional_headers'] : ''; ?></textarea>
+										<textarea name="additional_headers" class="visualizer-input" placeholder="<?php esc_html_e( 'Key:Value, Key2:Value2,...', 'visualizer' ); ?>"><?php echo esc_textarea( isset( $headers['additional_headers'] ) ? $headers['additional_headers'] : '' ); ?></textarea>
 									</div>
 								</div>
 							</div>
@@ -289,7 +294,7 @@ ORDER BY YEAR(post_date) DESC, MONTH(post_date) DESC;';
 						<?php
 						if ( ! empty( $root ) ) {
 							?>
-							<option value="<?php echo esc_attr( $root ); ?>"><?php echo str_replace( Visualizer_Source_Json::TAG_SEPARATOR, Visualizer_Source_Json::TAG_SEPARATOR_VIEW, $root ); ?></option>
+							<option value="<?php echo esc_attr( $root ); ?>"><?php echo esc_html( str_replace( Visualizer_Source_Json::TAG_SEPARATOR, Visualizer_Source_Json::TAG_SEPARATOR_VIEW, $root ) ); ?></option>
 							<?php
 						}
 						?>
@@ -307,7 +312,7 @@ ORDER BY YEAR(post_date) DESC, MONTH(post_date) DESC;';
 								<?php
 								if ( ! empty( $paging ) ) {
 									?>
-									<option value="<?php echo esc_attr( $paging ); ?>"><?php echo sprintf( 'Get results from the first %d pages using %s', apply_filters( 'visualizer_json_fetch_pages', 5, $url ), str_replace( Visualizer_Source_Json::TAG_SEPARATOR, Visualizer_Source_Json::TAG_SEPARATOR_VIEW, $paging ) ); ?></option>
+									<option value="<?php echo esc_attr( $paging ); ?>"><?php echo esc_html( sprintf( 'Get results from the first %d pages using %s', apply_filters( 'visualizer_json_fetch_pages', 5, $url ), str_replace( Visualizer_Source_Json::TAG_SEPARATOR, Visualizer_Source_Json::TAG_SEPARATOR_VIEW, $paging ) ) ); ?></option>
 									<?php
 								}
 								?>

--- a/tests/test-ajax.php
+++ b/tests/test-ajax.php
@@ -1164,67 +1164,197 @@ class Test_Visualizer_Ajax extends WP_Ajax_UnitTestCase {
 	}
 
 	/**
-	 * Saving a JSON data source must store sanitized credentials and root.
+	 * Saving a JSON data source must store the credential bytes exactly as sent.
 	 *
-	 * Covers the write boundary end to end: without the sanitization in
-	 * setJsonData() the payload reaches the post meta verbatim.
+	 * The credentials are base64-encoded into the Authorization header, so any
+	 * transform on the way into the meta breaks authentication. sanitize_text_field()
+	 * strips %XX octets, which silently turns abc%2Fdef into abcdef.
 	 */
-	public function test_json_set_data_sanitizes_stored_credentials_meta() {
+	public function test_json_set_data_preserves_credential_bytes_in_meta() {
 		wp_set_current_user( $this->admin_user_id );
 		$chart_id = $this->create_chart_for_user( $this->admin_user_id );
 
 		$this->handle_json_set_data(
 			$chart_id,
 			array(
-				'root'     => 'items<script>alert(1)</script>',
-				'username' => '<script>alert(document.domain)</script>admin',
-				'password' => '<img src=x onerror=alert(document.cookie)>secret',
+				'root'     => 'data%2Fresults',
+				'username' => 'AKIA%2FEXAMPLE%2BKEY',
+				'password' => 'p%40ssw0rd!#$^&*()_+=[]{};:,.?/|~',
 			)
 		);
 
 		$headers = get_post_meta( $chart_id, Visualizer_Plugin::CF_JSON_HEADERS, true );
 		$this->assertIsArray( $headers );
-		$this->assertSame( 'admin', $headers['auth']['username'] );
-		$this->assertSame( 'secret', $headers['auth']['password'] );
-		$this->assertSame( 'items', get_post_meta( $chart_id, Visualizer_Plugin::CF_JSON_ROOT, true ) );
+		$this->assertSame( 'AKIA%2FEXAMPLE%2BKEY', $headers['auth']['username'] );
+		$this->assertSame( 'p%40ssw0rd!#$^&*()_+=[]{};:,.?/|~', $headers['auth']['password'] );
+		$this->assertSame( 'data%2Fresults', get_post_meta( $chart_id, Visualizer_Plugin::CF_JSON_ROOT, true ) );
 	}
 
 	/**
-	 * The authorization-string form of the credentials is sanitized on save too.
+	 * A percent-encoded authorization string is stored byte for byte.
 	 */
-	public function test_json_set_data_sanitizes_stored_authorization_string() {
+	public function test_json_set_data_preserves_authorization_string_bytes() {
 		wp_set_current_user( $this->admin_user_id );
 		$chart_id = $this->create_chart_for_user( $this->admin_user_id );
 
-		$this->handle_json_set_data( $chart_id, array( 'auth' => '"><script>alert(1)</script>' ) );
+		$this->handle_json_set_data( $chart_id, array( 'auth' => 'SharedKey acct:aGVsbG8%3D' ) );
 
 		$headers = get_post_meta( $chart_id, Visualizer_Plugin::CF_JSON_HEADERS, true );
-		$this->assertIsArray( $headers );
-		$this->assertIsString( $headers['auth'] );
-		$this->assertStringNotContainsString( '<script', $headers['auth'] );
-		$this->assertStringNotContainsString( 'alert(', $headers['auth'] );
+		$this->assertSame( 'SharedKey acct:aGVsbG8%3D', $headers['auth'] );
 	}
 
 	/**
-	 * Real credentials must reach the post meta unchanged.
+	 * A markup payload is stored unmodified; escaping belongs to each output context.
+	 *
+	 * Guards against re-introducing write-time sanitization: the editor escaping is
+	 * covered by Test_Visualizer_Json_Headers_Xss.
 	 */
-	public function test_json_set_data_preserves_legitimate_credentials() {
+	public function test_json_set_data_stores_markup_payload_unmodified() {
 		wp_set_current_user( $this->admin_user_id );
 		$chart_id = $this->create_chart_for_user( $this->admin_user_id );
+
+		$payload = '<script>alert(1)</script>admin';
+		$this->handle_json_set_data(
+			$chart_id,
+			array(
+				'username' => $payload,
+				'password' => $payload,
+			)
+		);
+
+		$headers = get_post_meta( $chart_id, Visualizer_Plugin::CF_JSON_HEADERS, true );
+		$this->assertSame( $payload, $headers['auth']['username'] );
+		$this->assertSame( $payload, $headers['auth']['password'] );
+	}
+
+	/**
+	 * Render the JSON parameters screen for a chart.
+	 *
+	 * The upsell markup calls into the themeisle SDK, which the test bootstrap does
+	 * not load, so it is unhooked for the render and restored afterwards.
+	 *
+	 * @param int $chart_id The chart to render.
+	 * @return string The rendered markup.
+	 */
+	private function render_json_screen( $chart_id ) {
+		global $wp_filter;
+		$callbacks = isset( $wp_filter['visualizer_pro_upsell'] ) ? $wp_filter['visualizer_pro_upsell']->callbacks : array();
+		remove_all_filters( 'visualizer_pro_upsell' );
+
+		ob_start();
+		Visualizer_Render_Layout::show( 'json-screen', $chart_id );
+		$markup = ob_get_clean();
+
+		if ( ! empty( $callbacks ) ) {
+			$wp_filter['visualizer_pro_upsell']            = new WP_Hook();
+			$wp_filter['visualizer_pro_upsell']->callbacks = $callbacks;
+		}
+
+		return $markup;
+	}
+
+	/**
+	 * Assert that an input carries the value as inert text and no injected behaviour.
+	 *
+	 * @param DOMXPath $xpath    The parsed markup.
+	 * @param string   $input_id The input to check.
+	 * @param string   $expected The value the browser should read back.
+	 */
+	private function assertInputIsInert( DOMXPath $xpath, $input_id, $expected ) {
+		$input = $xpath->query( '//input[@id="' . $input_id . '"]' )->item( 0 );
+		$this->assertNotNull( $input, $input_id . ' is missing from the rendered markup.' );
+
+		// the browser reads the payload back as one literal string, not as markup.
+		$this->assertSame( $expected, $input->getAttribute( 'value' ) );
+
+		$attributes = array();
+		foreach ( $input->attributes as $attribute ) {
+			$attributes[] = strtolower( $attribute->nodeName );
+		}
+
+		$handlers = array_values(
+			array_filter(
+				$attributes,
+				function ( $name ) {
+					return 0 === strpos( $name, 'on' );
+				}
+			)
+		);
+
+		$this->assertSame( array(), $handlers, 'Event handler attributes were injected into ' . $input_id . '.' );
+		$this->assertNotContains( 'autofocus', $attributes, 'An autofocus attribute was injected into ' . $input_id . '.' );
+	}
+
+	/**
+	 * A script payload saved through the handler is inert once the editor renders it.
+	 *
+	 * The bytes are stored verbatim, so this is what proves the payload cannot run:
+	 * the rendered markup carries no script element and the value stays a single
+	 * attribute string with no event handler broken out of it.
+	 *
+	 * @requires extension dom
+	 */
+	public function test_json_set_data_payload_is_inert_when_rendered() {
+		wp_set_current_user( $this->admin_user_id );
+		$chart_id = $this->create_chart_for_user( $this->admin_user_id );
+
+		$username_payload = 'x" autofocus onfocus="alert(document.domain)" x="';
+		$password_payload = '"><script>alert(document.cookie)</script>';
 
 		$this->handle_json_set_data(
 			$chart_id,
 			array(
-				'root'     => 'data.results',
-				'username' => 'api_user-01@example.com',
-				'password' => 'p@ssw0rd!#$^&*()_+=[]{};:,.?/|~',
+				'username' => $username_payload,
+				'password' => $password_payload,
 			)
 		);
 
 		$headers = get_post_meta( $chart_id, Visualizer_Plugin::CF_JSON_HEADERS, true );
-		$this->assertSame( 'api_user-01@example.com', $headers['auth']['username'] );
-		$this->assertSame( 'p@ssw0rd!#$^&*()_+=[]{};:,.?/|~', $headers['auth']['password'] );
-		$this->assertSame( 'data.results', get_post_meta( $chart_id, Visualizer_Plugin::CF_JSON_ROOT, true ) );
+		$this->assertSame( $username_payload, $headers['auth']['username'] );
+		$this->assertSame( $password_payload, $headers['auth']['password'] );
+
+		$markup = $this->render_json_screen( $chart_id );
+
+		$dom = new DOMDocument();
+		libxml_use_internal_errors( true );
+		$dom->loadHTML( '<html><head><meta charset="utf-8"></head><body>' . $markup . '</body></html>' );
+		libxml_clear_errors();
+		libxml_use_internal_errors( false );
+
+		$this->assertSame( 0, $dom->getElementsByTagName( 'script' )->length, 'The payload created a script element.' );
+		$this->assertSame( 0, $dom->getElementsByTagName( 'img' )->length, 'The payload created an img element.' );
+
+		$xpath = new DOMXPath( $dom );
+		$this->assertInputIsInert( $xpath, 'vz-import-json-username', $username_payload );
+		$this->assertInputIsInert( $xpath, 'vz-import-json-password', $password_payload );
+	}
+
+	/**
+	 * An authorization-string script payload is inert once the editor renders it.
+	 *
+	 * @requires extension dom
+	 */
+	public function test_json_set_data_authorization_payload_is_inert_when_rendered() {
+		wp_set_current_user( $this->admin_user_id );
+		$chart_id = $this->create_chart_for_user( $this->admin_user_id );
+
+		$payload = '" onmouseover="alert(1)" data-x="<script>alert(2)</script>';
+		$this->handle_json_set_data( $chart_id, array( 'auth' => $payload ) );
+
+		$this->assertSame( $payload, get_post_meta( $chart_id, Visualizer_Plugin::CF_JSON_HEADERS, true )['auth'] );
+
+		$markup = $this->render_json_screen( $chart_id );
+
+		$dom = new DOMDocument();
+		libxml_use_internal_errors( true );
+		$dom->loadHTML( '<html><head><meta charset="utf-8"></head><body>' . $markup . '</body></html>' );
+		libxml_clear_errors();
+		libxml_use_internal_errors( false );
+
+		$this->assertSame( 0, $dom->getElementsByTagName( 'script' )->length, 'The payload created a script element.' );
+
+		$xpath = new DOMXPath( $dom );
+		$this->assertInputIsInert( $xpath, 'vz-import-json-auth', $payload );
 	}
 
 	/**

--- a/tests/test-ajax.php
+++ b/tests/test-ajax.php
@@ -1110,6 +1110,124 @@ class Test_Visualizer_Ajax extends WP_Ajax_UnitTestCase {
 	}
 
 	/**
+	 * Mock the JSON endpoint so the set-data handler does not hit the network.
+	 *
+	 * @return callable The filter callback, for removal.
+	 */
+	private function mock_json_endpoint() {
+		$filter = function () {
+			return array(
+				'headers'  => array(),
+				'body'     => wp_json_encode( array( array( 'name' => 'a', 'value' => 1 ) ) ),
+				'response' => array( 'code' => 200, 'message' => '' ),
+				'cookies'  => array(),
+				'filename' => null,
+			);
+		};
+		add_filter( 'pre_http_request', $filter );
+		return $filter;
+	}
+
+	/**
+	 * Run the JSON set-data handler as the current user.
+	 *
+	 * @param int   $chart_id The chart being saved.
+	 * @param array $post     The POST fields to send on top of the defaults.
+	 */
+	private function handle_json_set_data( $chart_id, array $post ) {
+		$_GET = array(
+			'chart'    => $chart_id,
+			'security' => wp_create_nonce( Visualizer_Plugin::ACTION_JSON_SET_DATA . Visualizer_Plugin::VERSION ),
+		);
+		// empty header/type keeps the editable-table parsing out of the assertions.
+		$_POST = array_merge(
+			array(
+				'url'    => 'https://example.com/data.json',
+				'method' => 'get',
+				'root'   => 'items',
+				'header' => array(),
+				'type'   => array(),
+			),
+			$post
+		);
+
+		$filter = $this->mock_json_endpoint();
+		try {
+			$this->_handleAjax( Visualizer_Plugin::ACTION_JSON_SET_DATA );
+		} catch ( WPAjaxDieContinueException $e ) {
+			// Expected once the update page has rendered.
+		} catch ( WPAjaxDieStopException $e ) {
+			// Expected when the handler produced no output.
+		} finally {
+			remove_filter( 'pre_http_request', $filter );
+		}
+	}
+
+	/**
+	 * Saving a JSON data source must store sanitized credentials and root.
+	 *
+	 * Covers the write boundary end to end: without the sanitization in
+	 * setJsonData() the payload reaches the post meta verbatim.
+	 */
+	public function test_json_set_data_sanitizes_stored_credentials_meta() {
+		wp_set_current_user( $this->admin_user_id );
+		$chart_id = $this->create_chart_for_user( $this->admin_user_id );
+
+		$this->handle_json_set_data(
+			$chart_id,
+			array(
+				'root'     => 'items<script>alert(1)</script>',
+				'username' => '<script>alert(document.domain)</script>admin',
+				'password' => '<img src=x onerror=alert(document.cookie)>secret',
+			)
+		);
+
+		$headers = get_post_meta( $chart_id, Visualizer_Plugin::CF_JSON_HEADERS, true );
+		$this->assertIsArray( $headers );
+		$this->assertSame( 'admin', $headers['auth']['username'] );
+		$this->assertSame( 'secret', $headers['auth']['password'] );
+		$this->assertSame( 'items', get_post_meta( $chart_id, Visualizer_Plugin::CF_JSON_ROOT, true ) );
+	}
+
+	/**
+	 * The authorization-string form of the credentials is sanitized on save too.
+	 */
+	public function test_json_set_data_sanitizes_stored_authorization_string() {
+		wp_set_current_user( $this->admin_user_id );
+		$chart_id = $this->create_chart_for_user( $this->admin_user_id );
+
+		$this->handle_json_set_data( $chart_id, array( 'auth' => '"><script>alert(1)</script>' ) );
+
+		$headers = get_post_meta( $chart_id, Visualizer_Plugin::CF_JSON_HEADERS, true );
+		$this->assertIsArray( $headers );
+		$this->assertIsString( $headers['auth'] );
+		$this->assertStringNotContainsString( '<script', $headers['auth'] );
+		$this->assertStringNotContainsString( 'alert(', $headers['auth'] );
+	}
+
+	/**
+	 * Real credentials must reach the post meta unchanged.
+	 */
+	public function test_json_set_data_preserves_legitimate_credentials() {
+		wp_set_current_user( $this->admin_user_id );
+		$chart_id = $this->create_chart_for_user( $this->admin_user_id );
+
+		$this->handle_json_set_data(
+			$chart_id,
+			array(
+				'root'     => 'data.results',
+				'username' => 'api_user-01@example.com',
+				'password' => 'p@ssw0rd!#$^&*()_+=[]{};:,.?/|~',
+			)
+		);
+
+		$headers = get_post_meta( $chart_id, Visualizer_Plugin::CF_JSON_HEADERS, true );
+		$this->assertSame( 'api_user-01@example.com', $headers['auth']['username'] );
+		$this->assertSame( 'p@ssw0rd!#$^&*()_+=[]{};:,.?/|~', $headers['auth']['password'] );
+		$this->assertSame( 'data.results', get_post_meta( $chart_id, Visualizer_Plugin::CF_JSON_ROOT, true ) );
+	}
+
+	/**
 	 * A user cannot save filters on another user's chart.
 	 */
 	public function test_save_filter_denied_for_chart_user_cannot_edit() {

--- a/tests/test-json-headers-xss.php
+++ b/tests/test-json-headers-xss.php
@@ -1,0 +1,292 @@
+<?php
+/**
+ * WordPress unit test plugin.
+ *
+ * @package     visualizer
+ * @subpackage  Tests
+ */
+
+/**
+ * Test that the JSON data source headers cannot carry stored XSS into the chart editor.
+ */
+class Test_Visualizer_Json_Headers_Xss extends WP_UnitTestCase {
+
+	/**
+	 * A payload that breaks out of an HTML value attribute.
+	 *
+	 * @var string
+	 */
+	const PAYLOAD = 'x" autofocus onfocus=alert(document.domain) x="';
+
+	/**
+	 * Callbacks removed from the pro upsell filter for the duration of a test.
+	 *
+	 * @var array
+	 */
+	private $upsell_callbacks = array();
+
+	/**
+	 * The upsell markup calls into the themeisle SDK, which the test bootstrap does
+	 * not load, so it is unhooked while the editor screen is rendered.
+	 */
+	public function set_up() {
+		parent::set_up();
+		global $wp_filter;
+		if ( isset( $wp_filter['visualizer_pro_upsell'] ) ) {
+			$this->upsell_callbacks = $wp_filter['visualizer_pro_upsell']->callbacks;
+			remove_all_filters( 'visualizer_pro_upsell' );
+		}
+	}
+
+	/**
+	 * Restore the upsell filter so no state leaks into other tests.
+	 */
+	public function tear_down() {
+		if ( ! empty( $this->upsell_callbacks ) ) {
+			global $wp_filter;
+			$wp_filter['visualizer_pro_upsell'] = new WP_Hook();
+			$wp_filter['visualizer_pro_upsell']->callbacks = $this->upsell_callbacks;
+			$this->upsell_callbacks = array();
+		}
+		parent::tear_down();
+	}
+
+	/**
+	 * Invoke the private Visualizer_Module_Chart::sanitizeJsonHeaders().
+	 *
+	 * @param mixed $headers The raw headers.
+	 * @return array The sanitized headers.
+	 */
+	private function sanitize( $headers ) {
+		$module = new Visualizer_Module_Chart( Visualizer_Plugin::instance() );
+		$method = new ReflectionMethod( Visualizer_Module_Chart::class, 'sanitizeJsonHeaders' );
+		$method->setAccessible( true );
+		return $method->invoke( $module, $headers );
+	}
+
+	/**
+	 * Create a chart carrying the given JSON headers meta.
+	 *
+	 * @param array $headers The headers to store.
+	 * @return int The chart id.
+	 */
+	private function create_chart_with_headers( array $headers ) {
+		$chart_id = $this->factory->post->create(
+			array(
+				'post_type'   => Visualizer_Plugin::CPT_VISUALIZER,
+				'post_status' => 'publish',
+			)
+		);
+		update_post_meta( $chart_id, Visualizer_Plugin::CF_JSON_URL, 'https://example.com/api' );
+		update_post_meta( $chart_id, Visualizer_Plugin::CF_JSON_HEADERS, $headers );
+		return $chart_id;
+	}
+
+	/**
+	 * Render the JSON parameters screen for a chart.
+	 *
+	 * @param int $chart_id The chart id.
+	 * @return string The rendered markup.
+	 */
+	private function render_json_screen( $chart_id ) {
+		ob_start();
+		Visualizer_Render_Layout::show( 'json-screen', $chart_id );
+		return ob_get_clean();
+	}
+
+	/**
+	 * Tag payloads are stripped from the credential fields on save.
+	 *
+	 * The write boundary removes markup so the stored value is safe for consumers
+	 * that are not HTML attributes (the REST field the block editor reads). The
+	 * quote break-out itself is stopped by escaping at output, which is context
+	 * specific and must not be done on the way into the database.
+	 */
+	public function test_sanitize_strips_tags_from_credentials() {
+		$result = $this->sanitize(
+			array(
+				'method' => 'get',
+				'auth'   => array(
+					'username' => '<script>alert(document.domain)</script>admin',
+					'password' => '<img src=x onerror=alert(document.cookie)>secret',
+				),
+			)
+		);
+
+		$this->assertStringNotContainsString( '<script', $result['auth']['username'] );
+		$this->assertStringNotContainsString( 'alert(document.domain)', $result['auth']['username'] );
+		$this->assertStringNotContainsString( '<img', $result['auth']['password'] );
+		$this->assertStringNotContainsString( 'onerror', $result['auth']['password'] );
+	}
+
+	/**
+	 * The authorization-string form of auth is sanitized too.
+	 */
+	public function test_sanitize_strips_tags_from_authorization_string() {
+		$result = $this->sanitize(
+			array(
+				'method' => 'get',
+				'auth'   => '"><script>alert(1)</script>',
+			)
+		);
+
+		$this->assertStringNotContainsString( '<script', $result['auth'] );
+		$this->assertStringNotContainsString( 'alert(1)', $result['auth'] );
+	}
+
+	/**
+	 * Newlines cannot be smuggled into the stored credential values.
+	 */
+	public function test_sanitize_strips_newlines_from_credentials() {
+		$result = $this->sanitize(
+			array(
+				'auth' => array(
+					'username' => "admin\nX-Injected: 1",
+					'password' => "secret\r\nX-Injected: 1",
+				),
+			)
+		);
+
+		$this->assertStringNotContainsString( "\n", $result['auth']['username'] );
+		$this->assertStringNotContainsString( "\r", $result['auth']['password'] );
+	}
+
+	/**
+	 * Legitimate credentials must survive sanitization byte for byte.
+	 */
+	public function test_sanitize_preserves_legitimate_credentials() {
+		$headers = array(
+			'method' => 'post',
+			'auth'   => array(
+				'username' => 'api_user-01@example.com',
+				'password' => 'p@ssw0rd!#$%^&*()_+=[]{};:,.?/|~',
+			),
+		);
+
+		$result = $this->sanitize( $headers );
+
+		$this->assertSame( $headers['auth']['username'], $result['auth']['username'] );
+		$this->assertSame( $headers['auth']['password'], $result['auth']['password'] );
+		$this->assertSame( 'post', $result['method'] );
+	}
+
+	/**
+	 * A shared-key authorization string must survive sanitization byte for byte.
+	 */
+	public function test_sanitize_preserves_shared_key_authorization() {
+		$auth   = 'SharedKey myaccount:aGVsbG8gd29ybGQ=';
+		$result = $this->sanitize( array( 'auth' => $auth ) );
+
+		$this->assertSame( $auth, $result['auth'] );
+	}
+
+	/**
+	 * Payloads already stored in the meta are escaped when the editor renders them.
+	 *
+	 * This covers the sites that stored a payload before the sanitizer existed, so it
+	 * must keep passing independently of the write-side fix.
+	 */
+	public function test_stored_credential_payload_is_escaped_on_render() {
+		$chart_id = $this->create_chart_with_headers(
+			array(
+				'method' => 'get',
+				'auth'   => array(
+					'username' => self::PAYLOAD,
+					'password' => self::PAYLOAD,
+				),
+			)
+		);
+
+		$markup = $this->render_json_screen( $chart_id );
+
+		$this->assertStringNotContainsString( self::PAYLOAD, $markup );
+		$this->assertStringContainsString( 'x&quot; autofocus onfocus=', $markup );
+	}
+
+	/**
+	 * A stored authorization string payload is escaped when the editor renders it.
+	 */
+	public function test_stored_authorization_payload_is_escaped_on_render() {
+		$chart_id = $this->create_chart_with_headers(
+			array(
+				'method' => 'get',
+				'auth'   => '"><img src=x onerror=alert(1)>',
+			)
+		);
+
+		$markup = $this->render_json_screen( $chart_id );
+
+		$this->assertStringNotContainsString( '<img src=x', $markup );
+		$this->assertStringContainsString( '&lt;img src=x', $markup );
+	}
+
+	/**
+	 * The editor renders without fatalling when auth is stored as a plain string.
+	 *
+	 * The string form used to reach array_key_exists(), which is a TypeError on
+	 * PHP 8 and took the whole chart editor page down.
+	 */
+	public function test_authorization_string_renders_without_fatal() {
+		$chart_id = $this->create_chart_with_headers(
+			array(
+				'method' => 'get',
+				'auth'   => 'SharedKey myaccount:aGVsbG8=',
+			)
+		);
+
+		$markup = $this->render_json_screen( $chart_id );
+
+		$this->assertStringContainsString( 'value="SharedKey myaccount:aGVsbG8="', $markup );
+		$this->assertStringContainsString( 'id="vz-import-json-username"', $markup );
+	}
+
+	/**
+	 * A stored additional_headers payload is escaped in the textarea.
+	 */
+	public function test_stored_additional_headers_payload_is_escaped_on_render() {
+		$chart_id = $this->create_chart_with_headers(
+			array(
+				'method'             => 'get',
+				'additional_headers' => '</textarea><img src=x onerror=alert(1)>',
+			)
+		);
+
+		$markup = $this->render_json_screen( $chart_id );
+
+		$this->assertStringNotContainsString( '</textarea><img', $markup );
+		$this->assertStringContainsString( '&lt;/textarea&gt;', $markup );
+	}
+
+	/**
+	 * A stored JSON root payload is escaped in the root dropdown label.
+	 */
+	public function test_stored_json_root_payload_is_escaped_on_render() {
+		$chart_id = $this->create_chart_with_headers( array( 'method' => 'get' ) );
+		update_post_meta( $chart_id, Visualizer_Plugin::CF_JSON_ROOT, '<img src=x onerror=alert(1)>' );
+
+		$markup = $this->render_json_screen( $chart_id );
+
+		$this->assertStringNotContainsString( '<img src=x', $markup );
+		$this->assertStringContainsString( '&lt;img src=x', $markup );
+	}
+
+	/**
+	 * Legitimate credentials still render as usable values in the editor.
+	 */
+	public function test_legitimate_credentials_render_intact() {
+		$chart_id = $this->create_chart_with_headers(
+			array(
+				'method' => 'get',
+				'auth'   => array(
+					'username' => 'api_user',
+					'password' => 'secret123',
+				),
+			)
+		);
+
+		$markup = $this->render_json_screen( $chart_id );
+
+		$this->assertStringContainsString( 'value="api_user"', $markup );
+		$this->assertStringContainsString( 'value="secret123"', $markup );
+	}
+}

--- a/tests/test-json-headers-xss.php
+++ b/tests/test-json-headers-xss.php
@@ -52,19 +52,6 @@ class Test_Visualizer_Json_Headers_Xss extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Invoke the private Visualizer_Module_Chart::sanitizeJsonHeaders().
-	 *
-	 * @param mixed $headers The raw headers.
-	 * @return array The sanitized headers.
-	 */
-	private function sanitize( $headers ) {
-		$module = new Visualizer_Module_Chart( Visualizer_Plugin::instance() );
-		$method = new ReflectionMethod( Visualizer_Module_Chart::class, 'sanitizeJsonHeaders' );
-		$method->setAccessible( true );
-		return $method->invoke( $module, $headers );
-	}
-
-	/**
 	 * Create a chart carrying the given JSON headers meta.
 	 *
 	 * @param array $headers The headers to store.
@@ -95,89 +82,43 @@ class Test_Visualizer_Json_Headers_Xss extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tag payloads are stripped from the credential fields on save.
+	 * Percent-encoded octets in a stored credential survive to the rendered value.
 	 *
-	 * The write boundary removes markup so the stored value is safe for consumers
-	 * that are not HTML attributes (the REST field the block editor reads). The
-	 * quote break-out itself is stopped by escaping at output, which is context
-	 * specific and must not be done on the way into the database.
+	 * Credentials are base64-encoded into the Authorization header, so the stored
+	 * bytes must be exact. sanitize_text_field() strips %XX octets and would turn
+	 * abc%2Fdef into abcdef, breaking authentication.
 	 */
-	public function test_sanitize_strips_tags_from_credentials() {
-		$result = $this->sanitize(
+	public function test_percent_encoded_credentials_render_intact() {
+		$chart_id = $this->create_chart_with_headers(
 			array(
 				'method' => 'get',
 				'auth'   => array(
-					'username' => '<script>alert(document.domain)</script>admin',
-					'password' => '<img src=x onerror=alert(document.cookie)>secret',
+					'username' => 'AKIA%2FEXAMPLE%2BKEY',
+					'password' => 'abc%2Fdef',
 				),
 			)
 		);
 
-		$this->assertStringNotContainsString( '<script', $result['auth']['username'] );
-		$this->assertStringNotContainsString( 'alert(document.domain)', $result['auth']['username'] );
-		$this->assertStringNotContainsString( '<img', $result['auth']['password'] );
-		$this->assertStringNotContainsString( 'onerror', $result['auth']['password'] );
+		$markup = $this->render_json_screen( $chart_id );
+
+		$this->assertStringContainsString( 'value="AKIA%2FEXAMPLE%2BKEY"', $markup );
+		$this->assertStringContainsString( 'value="abc%2Fdef"', $markup );
 	}
 
 	/**
-	 * The authorization-string form of auth is sanitized too.
+	 * A percent-encoded authorization string survives to the rendered value.
 	 */
-	public function test_sanitize_strips_tags_from_authorization_string() {
-		$result = $this->sanitize(
+	public function test_percent_encoded_authorization_renders_intact() {
+		$chart_id = $this->create_chart_with_headers(
 			array(
 				'method' => 'get',
-				'auth'   => '"><script>alert(1)</script>',
+				'auth'   => 'SharedKey acct:aGVsbG8%3D',
 			)
 		);
 
-		$this->assertStringNotContainsString( '<script', $result['auth'] );
-		$this->assertStringNotContainsString( 'alert(1)', $result['auth'] );
-	}
+		$markup = $this->render_json_screen( $chart_id );
 
-	/**
-	 * Newlines cannot be smuggled into the stored credential values.
-	 */
-	public function test_sanitize_strips_newlines_from_credentials() {
-		$result = $this->sanitize(
-			array(
-				'auth' => array(
-					'username' => "admin\nX-Injected: 1",
-					'password' => "secret\r\nX-Injected: 1",
-				),
-			)
-		);
-
-		$this->assertStringNotContainsString( "\n", $result['auth']['username'] );
-		$this->assertStringNotContainsString( "\r", $result['auth']['password'] );
-	}
-
-	/**
-	 * Legitimate credentials must survive sanitization byte for byte.
-	 */
-	public function test_sanitize_preserves_legitimate_credentials() {
-		$headers = array(
-			'method' => 'post',
-			'auth'   => array(
-				'username' => 'api_user-01@example.com',
-				'password' => 'p@ssw0rd!#$%^&*()_+=[]{};:,.?/|~',
-			),
-		);
-
-		$result = $this->sanitize( $headers );
-
-		$this->assertSame( $headers['auth']['username'], $result['auth']['username'] );
-		$this->assertSame( $headers['auth']['password'], $result['auth']['password'] );
-		$this->assertSame( 'post', $result['method'] );
-	}
-
-	/**
-	 * A shared-key authorization string must survive sanitization byte for byte.
-	 */
-	public function test_sanitize_preserves_shared_key_authorization() {
-		$auth   = 'SharedKey myaccount:aGVsbG8gd29ybGQ=';
-		$result = $this->sanitize( array( 'auth' => $auth ) );
-
-		$this->assertSame( $auth, $result['auth'] );
+		$this->assertStringContainsString( 'value="SharedKey acct:aGVsbG8%3D"', $markup );
 	}
 
 	/**


### PR DESCRIPTION
### Summary
Sanitize JSON headers to prevent XSS attacks in the chart editor.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/visualizer-pro/issues/618