### PR TITLE
fix: avoid counting malformed chart series metadata

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -13,6 +13,9 @@ jobs:
     strategy:
       fail-fast: false
     runs-on: ubuntu-22.04
+    env:
+      # PHP 7.4 images depend on the expired Debian Bullseye package index.
+      WP_ENV_PHP_VERSION: "8.2"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/classes/Visualizer/Gutenberg/Block.php
+++ b/classes/Visualizer/Gutenberg/Block.php
@@ -314,6 +314,9 @@ class Visualizer_Gutenberg_Block {
 
 		// faetch and update settings
 		$data['visualizer-settings'] = get_post_meta( $post_id, Visualizer_Plugin::CF_SETTINGS, true );
+		if ( ! is_array( $data['visualizer-settings'] ) ) {
+			$data['visualizer-settings'] = array();
+		}
 		if ( empty( $data['visualizer-settings']['pagination'] ) ) {
 			$data['visualizer-settings']['pageSize'] = '';
 		}

--- a/classes/Visualizer/Module/Frontend.php
+++ b/classes/Visualizer/Module/Frontend.php
@@ -750,7 +750,7 @@ class Visualizer_Module_Frontend extends Visualizer_Module {
 			$series                = get_post_meta( $chart->ID, Visualizer_Plugin::CF_SERIES, true );
 			$is_woocommerce_report = get_post_meta( $chart->ID, Visualizer_Plugin::CF_IS_WOOCOMMERCE_SOURCE, true );
 
-			if ( isset( $settings['series'] ) && ! ( count( $settings['series'] ) - count( $series ) > 1 ) ) {
+			if ( isset( $settings['series'] ) && is_array( $settings['series'] ) && is_array( $series ) && ! ( count( $settings['series'] ) - count( $series ) > 1 ) ) {
 				$diff_total_series = abs( count( $settings['series'] ) - count( $series ) );
 				if ( $diff_total_series ) {
 					foreach ( range( 1, $diff_total_series ) as $k => $diff_series ) {

--- a/tests/test-chart-data-permissions.php
+++ b/tests/test-chart-data-permissions.php
@@ -13,6 +13,20 @@
 class Test_Visualizer_Chart_Data_Permissions extends WP_UnitTestCase {
 
 	/**
+	 * A newly created REST chart has no settings metadata yet.
+	 */
+	public function test_rest_can_create_chart_without_settings_metadata() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/visualizer' );
+		$request->set_param( 'title', 'Empty chart' );
+		$request->set_param( 'status', 'publish' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 201, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertIsArray( $data['chart_data']['visualizer-settings'] );
+	}
+
+	/**
 	 * Create a chart owned by the given user.
 	 *
 	 * @param int $author_id The chart author.

--- a/tests/test-frontend-series.php
+++ b/tests/test-frontend-series.php
@@ -13,7 +13,20 @@ class Test_Visualizer_Frontend_Series extends WP_UnitTestCase {
 	public function test_chart_series_metadata( $settings_series, $series, $expected ) {
 		$id = self::factory()->post->create( array( 'post_type' => Visualizer_Plugin::CPT_VISUALIZER ) );
 		update_post_meta( $id, Visualizer_Plugin::CF_SETTINGS, array( 'series' => $settings_series ) );
-		update_post_meta( $id, Visualizer_Plugin::CF_SERIES, $series );
+		if ( is_bool( $series ) ) {
+			// WordPress persists scalar booleans as empty strings, so a stored boolean can only be
+			// observed by short-circuiting the lookup. WP_UnitTestCase removes the filter on tear down.
+			add_filter(
+				'get_post_metadata',
+				function ( $value, $object_id, $meta_key ) use ( $id, $series ) {
+					return (int) $object_id === $id && Visualizer_Plugin::CF_SERIES === $meta_key ? $series : $value;
+				},
+				10,
+				3
+			);
+		} else {
+			update_post_meta( $id, Visualizer_Plugin::CF_SERIES, $series );
+		}
 		$frontend = ( new ReflectionClass( 'Visualizer_Module_Frontend' ) )->newInstanceWithoutConstructor();
 		$method = new ReflectionMethod( $frontend, 'getChartData' );
 		$method->setAccessible( true );
@@ -22,13 +35,19 @@ class Test_Visualizer_Frontend_Series extends WP_UnitTestCase {
 		$this->assertEquals( $data, get_transient( 'series-test_' . $id ) );
 	}
 
+	/**
+	 * Settings-side values are stored inside a serialized array, so booleans and empty strings
+	 * survive as-is. Series-side booleans are injected through the metadata filter.
+	 */
 	public function series_values() {
 		return array(
-			'boolean settings' => array( false, array( array() ), false ),
-			'boolean columns' => array( array( array( 'color' => 'red' ) ), false, array( array( 'color' => 'red' ) ) ),
-			'missing columns' => array( array(), '', array() ),
-			'valid padding' => array( array( array( 'color' => 'red' ) ), array( array(), array() ), array( array( 'color' => 'red' ), array( 'color' => 'red' ) ) ),
-			'equal lengths' => array( array( array() ), array( array() ), array( array() ) ),
+			'boolean settings'     => array( false, array( array() ), false ),
+			'empty settings'       => array( '', array( array() ), '' ),
+			'boolean columns'      => array( array( array( 'color' => 'red' ) ), false, array( array( 'color' => 'red' ) ) ),
+			'empty columns'        => array( array( array( 'color' => 'red' ) ), '', array( array( 'color' => 'red' ) ) ),
+			'missing both'         => array( array(), '', array() ),
+			'valid padding'        => array( array( array( 'color' => 'red' ) ), array( array(), array() ), array( array( 'color' => 'red' ), array( 'color' => 'red' ) ) ),
+			'equal lengths'        => array( array( array() ), array( array() ), array( array() ) ),
 		);
 	}
 }

--- a/tests/test-frontend-series.php
+++ b/tests/test-frontend-series.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Chart series metadata regression tests.
+ *
+ * @package Visualizer
+ */
+class Test_Visualizer_Frontend_Series extends WP_UnitTestCase {
+	/**
+	 * Loading charts must tolerate malformed optional series metadata.
+	 *
+	 * @dataProvider series_values
+	 */
+	public function test_chart_series_metadata( $settings_series, $series, $expected ) {
+		$id = self::factory()->post->create( array( 'post_type' => Visualizer_Plugin::CPT_VISUALIZER ) );
+		update_post_meta( $id, Visualizer_Plugin::CF_SETTINGS, array( 'series' => $settings_series ) );
+		update_post_meta( $id, Visualizer_Plugin::CF_SERIES, $series );
+		$frontend = ( new ReflectionClass( 'Visualizer_Module_Frontend' ) )->newInstanceWithoutConstructor();
+		$method = new ReflectionMethod( $frontend, 'getChartData' );
+		$method->setAccessible( true );
+		$data = $method->invoke( $frontend, 'series-test', $id );
+		$this->assertSame( $expected, $data['settings']['series'] );
+		$this->assertEquals( $data, get_transient( 'series-test_' . $id ) );
+	}
+
+	public function series_values() {
+		return array(
+			'boolean settings' => array( false, array( array() ), false ),
+			'boolean columns' => array( array( array( 'color' => 'red' ) ), false, array( array( 'color' => 'red' ) ) ),
+			'missing columns' => array( array(), '', array() ),
+			'valid padding' => array( array( array( 'color' => 'red' ) ), array( array(), array() ), array( array( 'color' => 'red' ), array( 'color' => 'red' ) ) ),
+			'equal lengths' => array( array( array() ), array( array() ), array( array() ) ),
+		);
+	}
+}


### PR DESCRIPTION
Chart loading can fail on malformed series metadata (#1368), and REST chart creation fails when settings are missing. Both paths now validate metadata before using it.

## What changed

- **REST chart responses** initialize missing or invalid settings before adding default fields.

- **Chart loading** skips series padding for malformed metadata and preserves the existing behavior for valid chart series.

- **Regression tests** cover boolean and empty-string values on both the settings side and the series side, plus valid padding and equal lengths. WordPress stores a scalar `false` meta value as an empty string, so the boolean series case is injected through the `get_post_metadata` filter rather than written with `update_post_meta`.

- **Browser-test CI** uses PHP 8.2.

> [!NOTE]
> This prevents the PHP count error. It does not reconstruct missing chart data; affected charts can still require reimporting their data.

> [!NOTE]
> The browser tests now run on PHP 8.2 instead of the plugin's minimum PHP version, because the PHP 7.4 wp-env image depends on the expired Debian Bullseye package index. The runner's `setup-php` step still installs 7.4 for host tooling only. This is unrelated to the fix and can land separately if preferred.
